### PR TITLE
Lift & Serialize when update-macro state is static. More efficient.

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/BatchQueryExecution.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/BatchQueryExecution.scala
@@ -340,11 +340,13 @@ object BatchQueryExecution:
               '{ $batchContextOperation.execute(${Expr(query.basicQuery)}, $prepares.toList, $extractor, ExecutionInfo(ExecutionType.Static, ${Lifter(state.ast)})) }
 
             case None =>
-              report.warning(s"Could not create static state from the query: ${Format.Expr(expandedQuotation)}")
+              // TODO report via trace debug
+              //report.warning(s"Could not create static state from the query: ${Format.Expr(expandedQuotation)}")
               applyDynamic()
 
         case _ =>
-          report.warning(s"Batch actions must be static quotations. Found: ${Format.Expr(quoted)}", quoted)
+          // TODO report via trace debug
+          //report.warning(s"Batch actions must be static quotations. Found: ${Format.Expr(quoted)}", quoted)
           applyDynamic()
     end apply
 

--- a/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
@@ -9,7 +9,7 @@ class Is[T: Type]:
   def unapply(expr: Expr[Any])(using Quotes) =
     import quotes.reflect._
     if (expr.asTerm.tpe <:< TypeRepr.of[T])
-      Some(expr)
+      Some(expr.asExprOf[T])
     else
       None
 

--- a/quill-sql/src/main/scala/io/getquill/util/Format.scala
+++ b/quill-sql/src/main/scala/io/getquill/util/Format.scala
@@ -2,6 +2,7 @@ package io.getquill.util
 
 import scala.util.{ Try, Success, Failure }
 import scala.quoted._
+import io.getquill.util.ProtoMessages
 
 object Format {
   // import org.scalafmt.interfaces.Scalafmt
@@ -58,7 +59,17 @@ object Format {
 
     def Detail(expr: Expr[_])(using Quotes) =
       import quotes.reflect._
-      Format(Printer.TreeStructure.show(expr.asTerm))
+      val term = expr.asTerm
+      if (ProtoMessages.errorDetail) {
+        s"""|
+            |s"==== Expression ====
+            |  ${Format(Printer.TreeShortCode.show(term)) }
+            |==== Extractors ===
+            |  ${Format(Printer.TreeStructure.show(term))}
+            |""".stripMargin,
+      } else {
+        Format(Printer.TreeShortCode.show(term))
+      }
   }
 
   def apply(code: String) = {

--- a/quill-sql/src/main/scala/io/getquill/util/ProtoMessages.scala
+++ b/quill-sql/src/main/scala/io/getquill/util/ProtoMessages.scala
@@ -17,6 +17,7 @@ object ProtoMessages:
 
   private[getquill] def serializeAst = cache("quill.ast.serialize", variable("quill.ast.serialize", "quill_ast_serialize", "true").toBoolean)
   private[getquill] def maxQuatFields = cache("quill.quat.tooManyFields", variable("quill.quat.tooManyFields", "quill_quat_tooManyFields", "4").toInt)
+  private[getquill] def errorDetail = cache("quill.error.detail", variable("quill.error.detail", "quill_error_detail", "false").toBoolean)
 
 
 end ProtoMessages

--- a/quill-sql/src/main/scala/io/getquill/util/StringUtil.scala
+++ b/quill-sql/src/main/scala/io/getquill/util/StringUtil.scala
@@ -1,0 +1,13 @@
+package io.getquill.util
+
+object StringUtil {
+
+  def section(code: String): String = {
+    val lines = code.split("\n")
+    lines.tail.foldLeft("  |" + lines.head) { (out, line) =>
+      out + '\n' +
+        (if (line.isEmpty) line else "  |" + line)
+    }
+  }
+
+}


### PR DESCRIPTION
InsertUpdateMacro has four code paths, one where base entity of `SummonState` is static (*), one where it is dynamic (**),
and two orthogonal states where the insert assignments list (i.e. `query[Person].insert(_.name -> a, _.age -> b, etc...)`) is static or dynamic (based on a bunch of stuff including where a static or dynamic insert-meta could be found).

> * e.g. `query[Person].insert(Person(...))` where `query[Person]` expands to simple `'{ EntityQuery[t] }` or some other variations
> * e.g. `val runtimeEnt: Quoted[Query[Person]] = query[Person];  runtimeEnt.insert(Person(...))` where `query[Person]` is not known beyond being a `Expr[Query[Person]]`

Now in the case that everything is know statically i.e. both the assignments exclusion list via a compile-time known exclusion list (or a default empty one created in lieu of one existing), as well as the SummonState, we know we can get the entire Ast during compile time. We can then be more efficient and serialize it using `tryToSerialize` in the lifter.

This only works however when all the data we know is compile-time hence the Ast is available. If anything is dynamic, we cannot do that.

This PR adds a code-path in the case that everything is statically know to use `tryToSerialize` instead of standard serialization in this all-static case.