### PR TITLE
Various Fixes for Lifter and Unlifter

### DIFF
--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/FunctionQuotationTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/FunctionQuotationTest.scala
@@ -8,7 +8,7 @@ import org.scalatest._
 import io.getquill.quat.Quat
 import io.getquill._
 
-class FunctionQuotationTest extends Spec with Inside {
+class FunctionQuotationTest extends Spec with NonSerializingQuotation with Inside {
   // val ctx = new MirrorContext(MirrorIdiom, Literal)
   // import ctx._
 

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/FunctionTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/FunctionTest.scala
@@ -7,7 +7,7 @@ import io.getquill.ast.{Query => AQuery, _}
 import io.getquill.quat.Quat
 import io.getquill._
 
-class FunctionTest extends Spec with TestEntities {
+class FunctionTest extends Spec with NonSerializingQuotation with TestEntities {
   object IsDynamic {
     def apply(a: Ast) =
       CollectAst(a) { case d: Dynamic => d }.nonEmpty

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/IdentAndPropertyTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/IdentAndPropertyTest.scala
@@ -7,7 +7,7 @@ import io.getquill.ast.{Query => AQuery, _}
 import io.getquill.quat.Quat
 import io.getquill._
 
-class IdentAndPropertyTest extends Spec with TestEntities {
+class IdentAndPropertyTest extends Spec with NonSerializingQuotation with TestEntities {
   extension (ast: Ast)
     def body: Ast = ast match
       case f: Function => f.body

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/IfAndOrdTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/IfAndOrdTest.scala
@@ -4,7 +4,7 @@ import org.scalatest._
 import io.getquill._
 import io.getquill.ast._
 
-class IfAndOrdTest extends Spec with TestEntities with Inside {
+class IfAndOrdTest extends Spec with NonSerializingQuotation with TestEntities with Inside {
 
   extension (ast: Ast)
     def ordering: Ast = ast match

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/InfixTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/InfixTest.scala
@@ -13,7 +13,7 @@ import io.getquill.ast.Implicits._
 import io.getquill.norm.NormalizeStringConcat
 import io.getquill._
 
-class InfixTest extends Spec with Inside {
+class InfixTest extends Spec with NonSerializingQuotation with Inside {
   extension (ast: Ast)
     def body: Ast = ast match
       case f: Function => f.body

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/NonSerializingQuotation.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/NonSerializingQuotation.scala
@@ -1,0 +1,9 @@
+package io.getquill.ported.quotationspec
+
+import io.getquill.parser.SerializeAst
+
+/** In quotation tests, do not serialize the AST since
+  * we want to test the lifting/unlifting mechanism.
+  */
+trait NonSerializingQuotation:
+  inline given SerializeAst = SerializeAst.None

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/OperationTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/OperationTest.scala
@@ -13,7 +13,7 @@ import io.getquill.ast.Implicits._
 import io.getquill.norm.NormalizeStringConcat
 import io.getquill._
 
-class OperationTest extends Spec with TestEntities with Inside {
+class OperationTest extends Spec with NonSerializingQuotation with TestEntities with Inside {
 
   extension (ast: Ast)
     def body: Ast = ast match

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/OptionOperationTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/OptionOperationTest.scala
@@ -14,7 +14,7 @@ import io.getquill.norm.NormalizeStringConcat
 import io.getquill._
 import io.getquill.ast
 
-class OptionOperationTest extends Spec with Inside {
+class OptionOperationTest extends Spec with NonSerializingQuotation with Inside {
   "option operation" - {
     import io.getquill.ast.Implicits._
 

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/QuerySortByTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/QuerySortByTest.scala
@@ -8,7 +8,7 @@ import org.scalatest._
 import io.getquill.quat.Quat
 import io.getquill.Spec
 
-class QuerySortByTest extends Spec with Inside with TestEntities {
+class QuerySortByTest extends Spec with NonSerializingQuotation with Inside with TestEntities {
   // val ctx = new MirrorContext(MirrorIdiom, Literal)
   // import ctx._
 

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/QueryTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/QueryTest.scala
@@ -15,7 +15,7 @@ import scala.math.BigDecimal.{ double2bigDecimal, int2bigDecimal, javaBigDecimal
 case class CustomAnyValue(i: Int) extends AnyVal
 case class EmbeddedValue(s: String, i: Int) extends Embedded
 
-class QueryTest extends Spec with TestEntities {
+class QueryTest extends Spec with NonSerializingQuotation with TestEntities {
   // remove the === matcher from scalatest so that we can test === in Context.extra
   override def convertToEqualizer[T](left: T): Equalizer[T] = new Equalizer(left)
 

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/TraversableOperations.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/TraversableOperations.scala
@@ -13,7 +13,7 @@ import io.getquill.ast.Implicits._
 import io.getquill.norm.NormalizeStringConcat
 import io.getquill._
 
-class TraversableOperations extends Spec with TestEntities with Inside {
+class TraversableOperations extends Spec with NonSerializingQuotation with TestEntities with Inside {
 
   extension (ast: Ast)
     def body: Ast = ast match

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/ValueTest.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/quotationspec/ValueTest.scala
@@ -7,7 +7,7 @@ import io.getquill.ast.{Query => AQuery, _}
 import io.getquill.quat.Quat
 import io.getquill._
 
-class ValueTest extends Spec with TestEntities {
+class ValueTest extends Spec with NonSerializingQuotation with TestEntities {
   "value" - { //helloo
     "null" in {
       inline def q = quote("s" != null)

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/sqlidiomspec/ActionSpec.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/sqlidiomspec/ActionSpec.scala
@@ -8,7 +8,7 @@ import io.getquill.context.sql.testContext
 import io.getquill.context.sql.testContext._
 import io.getquill._
 
-class ActionSpec extends Spec {
+class ActionSpec extends Spec with NonSerializingQuotation {
   "action" - {
     "insert" - {
       "not affected by variable name" - {

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/sqlidiomspec/InfixSpec.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/sqlidiomspec/InfixSpec.scala
@@ -7,7 +7,7 @@ import io.getquill.context.sql.testContext
 import io.getquill.context.sql.testContext._
 import io.getquill._
 
-class InfixSpec extends Spec {
+class InfixSpec extends Spec with NonSerializingQuotation {
   "infix" - {
     "part of the query - pure" in {
       inline def q = quote {

--- a/quill-sql/src/main/scala/io/getquill/context/QuoteMacro.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/QuoteMacro.scala
@@ -13,6 +13,7 @@ import io.getquill.metaprog.Pluckable
 import io.getquill.metaprog.Pointable
 import io.getquill.Quoted
 import io.getquill.metaprog.SummonParser
+import io.getquill.metaprog.SummonSerializationBehaviors
 
 
 object ExtractLifts {
@@ -64,12 +65,14 @@ object QuoteMacro {
     val body = bodyRaw.asTerm.underlyingArgument.asExpr
 
     val parserFactory = SummonParser()
+    val (serializeQuats, serializeAst) = SummonSerializationBehaviors()
 
     import Parser._
 
     val rawAst = parserFactory.apply.seal.apply(body)
     val ast = BetaReduction(rawAst)
-    val reifiedAst = Lifter(ast)
+
+    val reifiedAst = Lifter.WithBehavior(serializeQuats, serializeAst)(ast)
 
     // Extract runtime quotes and lifts
     val (lifts, pluckedUnquotes) = ExtractLifts(bodyRaw)

--- a/quill-sql/src/main/scala/io/getquill/metaprog/SummonParser.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/SummonParser.scala
@@ -6,6 +6,24 @@ import io.getquill.util.Format
 import scala.quoted._
 import scala.util.Success
 import scala.util.Failure
+import io.getquill.parser.SerializeQuat
+import io.getquill.parser.SerializeAst
+
+object SummonSerializationBehaviors:
+  import scala.quoted._
+  /** Summon any serialization behavior defined on the context. If it does not exist return None */
+  def apply()(using Quotes): (Option[SerializeQuat], Option[SerializeAst]) =
+    import quotes.reflect._
+    // Find a SerializationBehavior and try to unlift it
+    val serializeAst =
+      Expr.summon[SerializeAst] match
+        case Some(value) => Some(SerializeAst.Lifter(value))
+        case None => None
+    val serializeQuat =
+      Expr.summon[SerializeQuat] match
+        case Some(value) => Some(SerializeQuat.Lifter(value))
+        case None => None
+    (serializeQuat, serializeAst)
 
 object SummonParser:
   def apply()(using Quotes): ParserFactory =

--- a/quill-sql/src/main/scala/io/getquill/parser/Serialize.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/Serialize.scala
@@ -1,6 +1,7 @@
 package io.getquill.parser
 
 import io.getquill.util.ProtoMessages
+import io.getquill.util.Format
 
 enum SerializeQuat:
   case All
@@ -8,10 +9,35 @@ enum SerializeQuat:
   case None
 
 object SerializeQuat:
+  object Lifter:
+    import scala.quoted._
+    given FromExpr[SerializeQuat] with
+      def unapply(expr: Expr[SerializeQuat])(using Quotes) =
+        import quotes.reflect._
+        expr match
+          case '{ SerializeQuat.All } => Some(SerializeQuat.All)
+          case '{ SerializeQuat.ByFieldCount(${Expr(i)}) } => Some(SerializeQuat.ByFieldCount(i))
+          case '{ SerializeQuat.None } => Some(SerializeQuat.None)
+          case _ => Option.empty[SerializeQuat]
+    def apply(expr: Expr[SerializeQuat])(using Quotes) =
+      import quotes.reflect._
+      expr.asTerm.underlyingArgument.asExprOf[SerializeQuat] match
+        case Expr(serializeQuat) => serializeQuat
+        case other => report.throwError(
+          s"""|Found an implicit instrument to Serialize Quats but could not read it from expression: ${Format.Expr(other)}.
+              |Make sure that the SerializeQuat implicit is defined as an inline-given (or implicit inline def) for example:
+              |inline given SerializeQuat = SerializeQuat.All
+              |val q = quote { myQuery } // will use the above given
+           """
+        )
+
+
   def global =
     if (ProtoMessages.maxQuatFields == 0) SerializeQuat.All
     else if (ProtoMessages.maxQuatFields < 0) SerializeQuat.None
     else SerializeQuat.ByFieldCount(ProtoMessages.maxQuatFields)
+
+end SerializeQuat
 
 enum SerializeAst:
   case All
@@ -20,3 +46,26 @@ enum SerializeAst:
 object SerializeAst:
   def global: SerializeAst =
     if (ProtoMessages.serializeAst) SerializeAst.All else SerializeAst.None
+
+  object Lifter:
+    import scala.quoted._
+    given FromExpr[SerializeAst] with
+      def unapply(expr: Expr[SerializeAst])(using Quotes) =
+        import quotes.reflect._
+        expr match
+          case '{ SerializeAst.All } => Some(SerializeAst.All)
+          case '{ SerializeAst.None } => Some(SerializeAst.None)
+          case _ => Option.empty[SerializeAst]
+    def apply(expr: Expr[SerializeAst])(using Quotes) =
+      import quotes.reflect._
+      expr.asTerm.underlyingArgument.asExprOf[SerializeAst] match
+        case Expr(serializeAst) => serializeAst
+        case other => report.throwError(
+          s"""|Found an implicit instrument to Serialize Asts but could not read it from expression: ${Format.Expr(other)}.
+              |Make sure that the SerializeAst implicit is defined as an inline-given (or implicit inline def) for example:
+              |inline given SerializeAst = SerializeAst.All
+              |val q = quote { myQuery } // will use the above given
+            """
+        )
+
+end SerializeAst

--- a/quill-sql/src/main/scala/io/getquill/parser/Unlifter.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/Unlifter.scala
@@ -231,6 +231,8 @@ object Unlifter {
       case Is[Take]( '{ Take($query, $num)} ) => Take(query.unexpr, num.unexpr)
       case Is[Drop]( '{ Drop($query, $num)} ) => Drop(query.unexpr, num.unexpr)
       case Is[ConcatMap]( '{ ConcatMap(${query}, ${alias}, ${body}: Ast) } ) => ConcatMap(query.unexpr, alias.unexpr, body.unexpr)
+      // Note: Aggregation is actually a Query-Type. Not sure why in Scala2-Quill it's not in the query-unlifter
+      case Is[Aggregation]( '{ Aggregation(${operator}, ${query}) } ) => Aggregation(operator.unexpr, query.unexpr)
 
   given unliftEntity: NiceUnliftable[Entity] with
     def unlift =
@@ -255,7 +257,6 @@ object Unlifter {
       case Is[If]( '{ If($cond, $thenStmt, $elseStmt) } ) => If(cond.unexpr, thenStmt.unexpr, elseStmt.unexpr)
       case Is[Function]( '{ Function($params, $body) } ) => Function(params.unexpr, body.unexpr)
       case Is[FunctionApply]( '{ FunctionApply($function, $values) } ) => FunctionApply(function.unexpr, values.unexpr)
-      case Is[Aggregation]( '{ Aggregation(${operator}, ${query}) } ) => Aggregation(operator.unexpr, query.unexpr)
       case Is[UnaryOperation]( '{ UnaryOperation(${operator}, ${a}: Ast) } ) => UnaryOperation(unliftOperator(operator).asInstanceOf[UnaryOperator], a.unexpr)
       case Is[BinaryOperation]( '{ BinaryOperation(${a}, ${operator}, ${b}: Ast) } ) => BinaryOperation(a.unexpr, unliftOperator(operator).asInstanceOf[BinaryOperator], b.unexpr)
       case Is[Property]( '{ Property(${ast}, ${name}) } ) => Property(ast.unexpr, constString(name))

--- a/quill-sql/src/test/scala/io/getquill/context/sql/OnConflictSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/context/sql/OnConflictSpec.scala
@@ -55,7 +55,7 @@ trait OnConflictSpec extends Spec {
   object `onConflictUpdate((t, e) => ...)` extends onConflictUpdate(3) {
     inline def testQuery(e: TestEntity) = quote {
       query[TestEntity]
-        .insert(lift(e)) //hello
+        .insert(lift(e))
         .onConflictUpdate((t, e) => t.s -> (t.s + "-" + e.s), (t, _) => t.l -> (t.l + 1))
     }
   }


### PR DESCRIPTION
Various things in the lifter and unlifter were incorrect. E.g. `Aggregation` should be in the QueryLifter and OnConflict lifting did not exist. This was hidden by the fact that Ast was binary-serialized instead of normally lifted in most cases.
A method of telling the `quote` macro not to serialize via `inline given` was introduced to disable Ast serialization for certain tests e.g. quotationspec tests.