### PR TITLE
making implicitDS available to streams

### DIFF
--- a/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioAppImplicitEnv.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/examples/ZioAppImplicitEnv.scala
@@ -25,6 +25,8 @@ object ZioAppImplicitEnv extends App {
     val joes = Ctx.run(query[Person].filter(p => p.name == "Joe")).implicitDS
     val jills = Ctx.run(query[Person].filter(p => p.name == "Jill")).implicitDS
     val alexes = Ctx.run(query[Person].filter(p => p.name == "Alex")).implicitDS
+
+    val janes = Ctx.stream(query[Person].filter(p => p.name == "Jane")).implicitDS.runCollect
   }
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] = {

--- a/quill-zio/src/main/scala/io/getquill/context/qzio/ImplicitSyntax.scala
+++ b/quill-zio/src/main/scala/io/getquill/context/qzio/ImplicitSyntax.scala
@@ -1,5 +1,6 @@
 package io.getquill.context.qzio
 
+import zio.stream.ZStream
 import zio.{ IO, ZIO }
 
 /**
@@ -43,5 +44,9 @@ object ImplicitSyntax {
 
   implicit final class ImplicitSyntaxOps[R, E, A](private val self: ZIO[R, E, A]) extends AnyVal {
     def implicitly(implicit r: Implicit[R]): IO[E, A] = self.provide(r.env)
+  }
+
+  implicit final class StreamImplicitSyntaxOps[R, E, A](private val self: ZStream[R, E, A]) extends AnyVal {
+    def implicitly(implicit r: Implicit[R]): ZStream[Any, E, A] = self.provide(r.env)
   }
 }


### PR DESCRIPTION
Fixes #33 

### Problem

We can't provide the ds implicitly to `stream` the same way we do with `run` 

### Solution

Make it available, being consistent with the api

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes
- [x] Run `sbt scalariformFormat test:scalariformFormat` to make sure that the source files are formatted

@getquill/maintainers
