### PR TITLE
Preserve existing errors when using transaction

### DIFF
--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioJdbcUnderlyingContext.scala
@@ -105,14 +105,16 @@ abstract class ZioJdbcUnderlyingContext[+Dialect <: SqlIdiom, +Naming <: NamingS
    * Note that for ZIO 2.0 since the env is covariant, R can be a subtype of connection because if there are other with-clauses
    * they can be generalized to Something <: Connection. E.g. `Connection with OtherStuff` generalizes to `Something <: Connection`.
    */
-  private[getquill] def withoutAutoCommit[R <: Connection, A, E <: Throwable: ClassTag](f: ZIO[R, E, A]): ZIO[R, E, A] = {
+  private[getquill] def withoutAutoCommit[R <: Connection, A, E](f: ZIO[R, E, A]): ZIO[R, E | SQLException, A] = {
     for {
       conn <- ZIO.service[Connection]
       autoCommitPrev = conn.getAutoCommit
-      r <- ZIO.acquireReleaseWith(sqlEffect(conn))(conn => ZIO.succeed(conn.setAutoCommit(autoCommitPrev))) { conn =>
-        sqlEffect(conn.setAutoCommit(false)).flatMap(_ => f)
-      }.refineToOrDie[E]
-    } yield r
+      result <- ZIO.acquireReleaseWith(sqlEffect(conn))(conn => ZIO.succeed(conn.setAutoCommit(autoCommitPrev))) { conn =>
+        // type has to be explicitly defined
+        val innerResult: ZIO[R, E | SQLException, A] = sqlEffect(conn.setAutoCommit(false)) *> f
+        innerResult
+      }
+    } yield result
   }
 
   private[getquill] def streamWithoutAutoCommit[A](f: ZStream[Connection, Throwable, A]): ZStream[Connection, Throwable, A] = {
@@ -125,20 +127,20 @@ abstract class ZioJdbcUnderlyingContext[+Dialect <: SqlIdiom, +Naming <: NamingS
     } yield r
   }
 
-  def transaction[R <: Connection, A](f: ZIO[R, Throwable, A]): ZIO[R, Throwable, A] = {
+  def transaction[R <: Connection, E, A](f: ZIO[R, E, A]): ZIO[R, E | SQLException, A] = {
     ZIO.environment[R].flatMap(env =>
-      blocking(withoutAutoCommit(
+      blocking(withoutAutoCommit {
         f.onExit {
           case Success(_) =>
             ZIO.succeed(env.get[Connection].commit())
           case Failure(cause) =>
-            ZIO.succeed(env.get[Connection].rollback()).foldCauseZIO(
+            sqlEffect(env.get[Connection].rollback()).foldCauseZIO(
               // NOTE: cause.flatMap(Cause.die) means wrap up the throwable failures into die failures, can only do if E param is Throwable (can also do .orDie at the end)
-              rollbackFailCause => ZIO.failCause(cause.flatMap(Cause.die(_, StackTrace.none)) ++ rollbackFailCause),
-              _ => ZIO.failCause(cause.flatMap(Cause.die(_, StackTrace.none))) // or ZIO.halt(cause).orDie
+              rollbackFailCause => ZIO.failCause(cause.flatMap(e => Cause.fail(e, StackTrace.none)).stripFailures ++ rollbackFailCause.stripFailures),
+              _ => ZIO.failCause(cause.flatMap(e => Cause.fail[E](e, StackTrace.none).stripFailures)) // or ZIO.halt(cause).orDie
             )
         }.provideEnvironment(env)
-      )))
+      }))
   }
 
   def probingDataSource: Option[DataSource] = None

--- a/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/QuillBaseContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/QuillBaseContext.scala
@@ -111,17 +111,17 @@ trait QuillBaseContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends 
    * Execute instructions in a transaction. For example, to add a Person row to the database and return
    * the contents of the Person table immediately after that:
    * {{{
-   *   val a = run(query[Person].insert(Person(...)): ZIO[Has[DataSource], SQLException, Long]
-   *   val b = run(query[Person]): ZIO[Has[DataSource], SQLException, Person]
-   *   transaction(a *> b): ZIO[Has[DataSource], SQLException, Person]
+   *   val a = run(query[Person].insert(Person(...)): ZIO[DataSource, SQLException, Long]
+   *   val b = run(query[Person]): ZIO[DataSource, SQLException, Person]
+   *   transaction(a *> b): ZIO[DataSource, SQLException, Person]
    * }}}
    */
-  def transaction[R, A](op: ZIO[R, Throwable, A]): ZIO[R, Throwable, A] =
+  def transaction[R, E ,A](op: ZIO[R, E, A]): ZIO[R, E | SQLException, A] =
     dsDelegate.transaction(op).provideSomeEnvironment[R]((env: ZEnvironment[R]) => env.add[DataSource](ds: DataSource))
 
-  private def onDS[T](qio: ZIO[DataSource, SQLException, T]): ZIO[Any, SQLException, T] =
+  private def onDS[T, E](qio: ZIO[DataSource, E, T]): ZIO[Any, E, T] =
     qio.provideEnvironment(ZEnvironment(ds))
 
-  private def onDSStream[T](qstream: ZStream[DataSource, SQLException, T]): ZStream[Any, SQLException, T] =
+  private def onDSStream[T, E](qstream: ZStream[DataSource, E, T]): ZStream[Any, E, T] =
     qstream.provideEnvironment(ZEnvironment(ds))
 }

--- a/quill-jdbc-zio/src/test/scala/io/getquill/misc/ZioJdbcUnderlyingContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/misc/ZioJdbcUnderlyingContextSpec.scala
@@ -75,6 +75,12 @@ class ZioJdbcUnderlyingContextSpec extends ZioProxySpec {
         r <- testContext.underlying.run(qr1)
       } yield r).onDataSource.runSyncUnsafe().map(_.i) mustEqual List(33)
     }
+    "keep existing errors" in {
+      import java.sql.{Connection, SQLException}
+
+      val zioThatCanFail: ZIO[Any, String, Nothing] = ZIO.fail("Custom Error")
+      "val result: ZIO[Connection, String | SQLException, List[TestEntity]] = testContext.underlying.transaction(zioThatCanFail *> testContext.underlying.run(qr1))" must compile
+    }
     // "prepare" in {
     //   testContext.underlying.prepareParams(
     //     "select * from Person where name=? and age > ?", (ps, session) => (List("Sarah", 127), ps)

--- a/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ZioJdbcContextSpec.scala
+++ b/quill-jdbc-zio/src/test/scala/io/getquill/postgres/ZioJdbcContextSpec.scala
@@ -76,5 +76,9 @@ class ZioJdbcContextSpec extends ZioSpec {
         "select * from Person where name=? and age > ?", (ps, session) => (List("Sarah", 127), ps)
       ).runSyncUnsafe() mustEqual List("127", "'Sarah'")
     }
+    "keep existing errors" in {
+      val zioThatCanFail: ZIO[Any, String, Nothing] = ZIO.fail("Custom Error")
+      "val result: ZIO[Any, String | SQLException, List[TestEntity]] = testContext.transaction(zioThatCanFail *> testContext.run(qr1))" must compile
+    }
   }
 }


### PR DESCRIPTION
Fixes #issue_number

### Problem

I would like to be able to run ZIO effects without losing existing information on error channel.

For example;
```scala

enum AppError {
  case UserNotFound(message: String) extends AppErrorScala3
  case InvalidCredentials(message: String) extends AppErrorScala3
}

val login: ZIO[Connection, SQLException | InvalidCredentials | UserNotFound, User] = for {
  maybeUser <- userRepository.findByEmail(email)
  user <- ZIO.getOrFailWith[UserNotFound, User](UserNotFound(s"User with given email [$email] is not found"))(
    maybeUser
  )
  result <- hasherService.check(plainTextPassword, user.hashedPassword)
  _      <- ZIO.fail[InvalidCredentials](InvalidCredentials("Invalid Credentials")).unless(result)
} yield user

// Given above code, if we were to run "login" effect in transaction we will lose existing errors.
val transactionResult: ZIO[Connection, Throwable, User] = ctx.underlying.transaction(login)

// I would like to be able to run "login" effect in transaction and still keep existing errors.
// This PR allows you to do the following
val transactionResult: ZIO[Connection, SQLException | InvalidCredentials | UserNotFound, User] = ctx.underlying.transaction(login)

// In case of missing SQLException in error channel, it should added to error channel along with the existing ones
val zioThatCanFailWithString = ZIO[Connection, String, User] = ???
val zioThatCanFailWithStringTransaction: ZIO[Connection, String | SQLException, User] = ctx.underlying.transaction(zioThatCanFailWithString)

```

### Solution

I changed `ZioJdbcUnderlyingContext.transaction`
```
// from
def transaction[R <: Connection, A](f: ZIO[R, Throwable, A]): ZIO[R, Throwable, A]
// to
def transaction[R <: Connection, E, A](f: ZIO[R, E, A]): ZIO[R, E | SQLException, A]
```

Also updated `QuillZioExtPlain.onDataSource` and `QuillZioExtPlain.implicitDS` so that can be run on `ZIO[Connection, E, T]` rather than `ZIO[Connection, Throwable, T]` 

### Notes

I only updated `ZioJdbcUnderlyingContext.transaction` as part of the initial PoC/Draft. If we are happy with the approach, we need to apply the same approach to `ZioJdbcContext.transaction` as well.

### Checklist

- [x] Unit test all changes - TODO
- [ ] Update `README.md` if applicable TODO
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
