### PR TITLE
Upgrade to latest version of ZIO (2.0.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        scala: [3.1.3]
+        scala: [3.2.2]
         module: [sqltest, db, async, bigdata]
 
     steps:
@@ -39,7 +39,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        scala: [3.1.3]
+        scala: [3.2.2]
         module: [base, db, async, bigdata, publish]
 
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -140,7 +140,7 @@ lazy val `quill-sql` =
         "com.lihaoyi" %% "pprint" % "0.6.6",
         "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
         "io.getquill" %% "quill-engine" % "4.6.0",
-        "dev.zio" %% "zio" % "2.0.2",
+        "dev.zio" %% "zio" % "2.0.8",
         ("io.getquill" %% "quill-util" % "4.6.0")
           .excludeAll({
             if (isCommunityBuild)
@@ -239,8 +239,8 @@ lazy val `quill-zio` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "dev.zio" %% "zio" % "2.0.2",
-        "dev.zio" %% "zio-streams" % "2.0.2"
+        "dev.zio" %% "zio" % "2.0.8",
+        "dev.zio" %% "zio-streams" % "2.0.8"
       )
     )
     .dependsOn(`quill-sql` % "compile->compile;test->test")
@@ -293,8 +293,8 @@ lazy val `quill-cassandra-zio` =
       Test / fork := true,
       libraryDependencies ++= Seq(
         "com.datastax.oss" % "java-driver-core" % "4.13.0",
-        "dev.zio" %% "zio" % "2.0.2",
-        "dev.zio" %% "zio-streams" % "2.0.2"
+        "dev.zio" %% "zio" % "2.0.8",
+        "dev.zio" %% "zio-streams" % "2.0.8"
       )
     )
     .dependsOn(`quill-cassandra` % "compile->compile;test->test")
@@ -345,7 +345,7 @@ lazy val basicSettings = Seq(
     ExclusionRule("org.scala-lang.modules", "scala-collection-compat_2.13")
   ),
   scalaVersion := {
-    if (isCommunityBuild) dottyLatestNightlyBuild().get else "3.1.3"
+    if (isCommunityBuild) dottyLatestNightlyBuild().get else "3.2.2"
   },
   organization := "io.getquill",
   // The -e option is the 'error' report of ScalaTest. We want it to only make a log

--- a/build/build.sh
+++ b/build/build.sh
@@ -24,7 +24,7 @@ export ORIENTDB_HOST=127.0.0.1
 export ORIENTDB_PORT=12424
 
 export GC_OPTS="-XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled"
-export JVM_OPTS="-Dcommunity=false -Dquill.macro.log=false -Xms1024m -Xmx3g -Xss5m ${GC_OPTS}"
+export JVM_OPTS="-Dcommunity=false -Dquill.macro.log=false -Xms1024m -Xmx4g -Xss5m ${GC_OPTS}"
 
 modules=$1
 


### PR DESCRIPTION
Fixes #217 

### Problem

The ZIO version used is currently set at 2.0.2. Using any version of ZIO later than 2.0.2 results in problems with the ZIO Environment.

### Solution

Upgrade the ZIO dependencies to the latest version.

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
