### PR TITLE
Update caliban to version 2.9.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -43,7 +43,7 @@ jobs:
 
   release:
     if: ${{github.event_name != 'pull_request'}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   scala-steward:
     timeout-minutes: 45
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Scala Steward
     steps:
       - name: Scala Steward

--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,7 @@ lazy val `quill-caliban` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.ghostdogpr" %% "caliban-quick" % "2.7.2",
+        "com.github.ghostdogpr" %% "caliban-quick" % "2.9.1",
         // Adding this to main dependencies would force users to use logback-classic for SLF4j unless the specifically remove it
         // seems to be safer to just exclude & add a commented about need for a SLF4j implementation in Docs.
         "ch.qos.logback" % "logback-classic" % "1.5.12" % Test,

--- a/quill-caliban/src/test/scala/io/getquill/example/CalibanExample.scala
+++ b/quill-caliban/src/test/scala/io/getquill/example/CalibanExample.scala
@@ -96,10 +96,6 @@ object CalibanExample extends zio.ZIOAppDefault {
         )
       )
     )
-  
-  given JsonEncoder[GraphQLRequest] = GraphQLRequest.zioJsonEncoder
-
-  given JsonDecoder[GraphQLRequest] = GraphQLRequest.zioJsonDecoder
 
   val myApp = for {
     _ <- Dao.resetDatabase()


### PR DESCRIPTION
Fixes #issue_number

### Problem

Updating caliban to the latest version 

### Solution

Updated caliban to version 2.9.1 and removed in the example the explicit definition of JSON decoders as they are not needed anymore.

### Notes

Fixes missing sbt in the CI pipeline as github runners after ubuntu-22.04 don't have it configured.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
