### PR TITLE
make error types more precise for `transaction` method

### DIFF
--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioPrepareContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioPrepareContext.scala
@@ -51,4 +51,8 @@ trait ZioPrepareContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends
           prepareSingle(sql, prepare)(info, dc)
       }
     }.refineToOrDie[SQLException]
+
+  final protected def sqlEffect[A](a: => A): ZIO[Any, SQLException, A] =
+    ZIO.attempt(a).refineToOrDie[SQLException]
+
 }

--- a/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/QuillBaseContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/jdbczio/QuillBaseContext.scala
@@ -116,7 +116,7 @@ trait QuillBaseContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends 
    *   transaction(a *> b): ZIO[Has[DataSource], SQLException, Person]
    * }}}
    */
-  def transaction[R, A](op: ZIO[R, Throwable, A]): ZIO[R, Throwable, A] =
+  def transaction[R, E, A](op: ZIO[R, E, A]): ZIO[R, E | SQLException, A] =
     dsDelegate.transaction(op).provideSomeEnvironment[R]((env: ZEnvironment[R]) => env.add[DataSource](ds: DataSource))
 
   private def onDS[T](qio: ZIO[DataSource, SQLException, T]): ZIO[Any, SQLException, T] =


### PR DESCRIPTION
I ran into a situation where I needed these more precise error types, so I thought I'd propose them upstream.

~~I have also noticed that in `ZioJdbcUnderlyingContext#transaction`, if the passed action `f` fails, the error will _always_ be wrapped in `Cause.die`, even if the rollback succeeds. I think that's a bug and therefore fixed it, and it has the nice additional benefit of getting rid of the `<: Throwable` constraint on the error type. But it is arguably an incompatible change of behaviour (like many bug fixes), so I thought I'd point it out.~~

Turns out I actually misread the code here, the error handling was working fine. 