### PR TITLE
Fix parsing of `augmentString(...).toInt` under Scala 3.8.0+ 

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
@@ -1018,6 +1018,16 @@ class OperationsParser(val rootParse: Parser)(using Quotes, TranspileConfig) ext
     case Unseal(Apply(Select(encodeable, "toString"), List())) if isValue(encodeable.tpe) =>
       val inner = rootParse(encodeable.asExpr)
       Infix(List("cast(", " as VARCHAR)"), List(inner), false, false, inner.quat)
+    
+    // Handle augmentString wrapper with Inlined blocks (Scala 3.8.0+)
+    // Pattern: augmentString(Inlined(...)).toXxx
+    // This handles the case where Scala 3.8.0+ creates Inlined blocks with context capture
+    case Unseal(Select(Apply(Ident("augmentString"), List(innerRaw)), ("toInt" | "toLong" | "toShort" | "toFloat" | "toDouble" | "toByte" | "toChar"))) if isValue(innerRaw.tpe) => 
+      def unwrapInlined(term: Term): Term = term match {
+        case Inlined(_, _, body) => unwrapInlined(body)
+        case other => other
+      }
+      rootParse(unwrapInlined(innerRaw).asExpr)
     case Unseal(Select(num, "toInt")) if isValue(num.tpe)    => rootParse(num.asExpr)
     case Unseal(Select(num, "toLong")) if isValue(num.tpe)   => rootParse(num.asExpr)
     case Unseal(Select(num, "toShort")) if isValue(num.tpe)  => rootParse(num.asExpr)


### PR DESCRIPTION
Fix parsing of `augmentString(...).toInt` under Scala 3.8.0+ due to changes in std-library being compiled using Scala 3

### Problem

Following code would fail to compile under Scala 3.8

```scala
//> using dep "io.getquill::quill-jdbc:4.8.6"
//> using scala 3.8.0-RC1 

package io.getquill.context.jdbc.sqlite

import io.getquill._

class ProductJdbcSpec { 
  object testContext extends SqliteJdbcContext(Literal, "testSqliteDB")// with TestEntities with TestEncoders with TestDecoders
  import testContext.*

  case class Product(id: Long, description: String, sku: Long)
  
  val queried = testContext.run {
    query[Product].filter(_.sku == lift("1004").toInt)
  }
}
```

Compilation failure below:

<details> 

```scala
[error] ./quill.repro.scala:14:36
[error] 
[error] s"==== Tree cannot be parsed to 'Ast' ====
[error]     augmentString({
[error]     val Context_this: testContext.type = ProductJdbcSpec.this.testContext
[error] 
[error]     (EagerPlanter
[error]       .apply[String, PrepareRow, Session](
[error]         "1004",
[error]         ProductJdbcSpec.this.testContext.stringEncoder,
[error]         "5f2ec913-db98-416c-b3cc-fa306b36af86"
[error]       )
[error]       .unquote: String)
[error]   })
[error] ==== Extractors ===
[error]   Apply(
[error]   Ident("augmentString"),
[error]   List(
[error]     Inlined(
[error]       Some(
[error]         Apply(
[error]           TypeApply(
[error]             Select(
[error]               Select(This(Some("ProductJdbcSpec")), "testContext"),
[error]               "lift"
[error]             ),
[error]             List(Inferred())
[error]           ),
[error]           List(Literal(StringConstant("1004")))
[error]         )
[error]       ),
[error]       List(
[error]         ValDef(
[error]           "Context_this",
[error]           Inferred(),
[error]           Some(Select(This(Some("ProductJdbcSpec")), "testContext"))
[error]         )
[error]       ),
[error]       Typed(
[error]         Select(
[error]           Apply(
[error]             TypeApply(
[error]               Select(Ident("EagerPlanter"), "apply"),
[error]               List(Inferred(), Inferred(), Inferred())
[error]             ),
[error]             List(
[error]               Literal(StringConstant("1004")),
[error]               Select(
[error]                 Select(This(Some("ProductJdbcSpec")), "testContext"),
[error]                 "stringEncoder"
[error]               ),
[error]               Literal(StringConstant("5f2ec913-db98-416c-b3cc-fa306b36af86"))
[error]             )
[error]           ),
[error]           "unquote"
[error]         ),
[error]         Inferred()
[error]       )
[error]     )
[error]   )
[error] )
[error] ==== Stacktrace ===
[error]   java.base/java.lang.Thread.getStackTrace(Thread.java:2451)
[error]   io.getquill.parser.engine.failParse$.apply(failParse.scala:29)
[error]   io.getquill.parser.engine.failParse$.apply(failParse.scala:13)
[error]   io.getquill.parser.engine.Parser.error(Parser.scala:10)
[error]   io.getquill.parser.engine.Parser.error$(Parser.scala:7)
[error]   io.getquill.parser.engine.ParserChain$$anon$1.error(ParserChain.scala:15)
[error]   io.getquill.parser.engine.Parser.apply$$anonfun$1(Parser.scala:9)
[error]   scala.Option.getOrElse(Option.scala:203)
[error]   io.getquill.parser.engine.Parser.apply(Parser.scala:9)
[error]   io.getquill.parser.engine.Parser.apply$(Parser.scala:7)
[error]   io.getquill.parser.engine.ParserChain$$anon$1.apply(ParserChain.scala:15)
[error]   io.getquill.parser.OperationsParser$$anon$21.applyOrElse(Parser.scala:1021)
[error]   io.getquill.parser.OperationsParser$$anon$21.applyOrElse(Parser.scala:977)
[error]   scala.PartialFunction$Lifted.apply(PartialFunction.scala:354)
[error]   scala.PartialFunction$Lifted.apply(PartialFunction.scala:353)
[error]   io.getquill.parser.engine.ParserChain$.io$getquill$parser$engine$ParserChain$OrElse$$anon$2$$_$$anonfun$1$$anonfun$1(ParserChain.scala:46)
[error]   scala.Option.orElse(Option.scala:479)
[error]   io.getquill.parser.engine.ParserChain$OrElse$$anon$2.$anonfun$1(ParserChain.scala:46)
[error]   scala.PartialFunction$$anon$2.applyOrElse(PartialFunction.scala:379)
[error]   scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:39)
[error]   io.getquill.parser.engine.ParserChain$OrElse$$anon$2.$anonfun$1(ParserChain.scala:46)
[error]   scala.PartialFunction$$anon$2.applyOrElse(PartialFunction.scala:379)
[error]   scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:39)
[error]   io.getquill.parser.engine.ParserChain$OrElse$$anon$2.$anonfun$1(ParserChain.scala:46)
[error]   scala.PartialFunction$$anon$2.applyOrElse(PartialFunction.scala:379)
[error]   scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:39)
[error]   io.getquill.parser.engine.ParserChain$OrElse$$anon$2.$anonfun$1(ParserChain.scala:46)
[error]   scala.PartialFunction$$anon$2.applyOrElse(PartialFunction.scala:379)
[error]   scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:39)
[error]   io.getquill.parser.engine.ParserChain$OrElse$$anon$2.$anonfun$1(ParserChain.scala:46)
[error]   scala.PartialFunction$$anon$2.applyOrElse(PartialFunction.scala:379)
[error]   scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:39)
[error]   io.getquill.parser.engine.ParserChain$OrElse$$anon$2.$anonfun$1(ParserChain.scala:46)
[error]   scala.PartialFunction$$anon$2.applyOrElse(PartialFunction.scala:379)
[error]   scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:39)
[error]   io.getquill.parser.engine.Parser.apply(Parser.scala:9)
[error]   io.getquill.parser.engine.Parser.apply$(Parser.scala:7)
[error]   io.getquill.parser.engine.ParserChain$$anon$1.apply(ParserChain.scala:15)
[error]   io.getquill.parser.ParserHelpers$ComparisonTechniques.equalityWithInnerTypechecksIdiomatic(ParserHelpers.scala:253)
[error]   io.getquill.parser.ParserHelpers$ComparisonTechniques.equalityWithInnerTypechecksIdiomatic$(ParserHelpers.scala:234)
[error]   io.getquill.parser.OperationsParser.equalityWithInnerTypechecksIdiomatic(Parser.scala:945)
[error]   io.getquill.parser.OperationsParser$$anon$21.applyOrElse(Parser.scala:995)
[error]   io.getquill.parser.OperationsParser$$anon$21.applyOrElse(Parser.scala:977)
[error]   scala.PartialFunction$Lifted.apply(PartialFunction.scala:354)
[error]   scala.PartialFunction$Lifted.apply(PartialFunction.scala:353)
[error]   io.getquill.parser.engine.ParserChain$.io$getquill$parser$engine$ParserChain$OrElse$$anon$2$$_$$anonfun$1$$anonfun$1(ParserChain.scala:46)
[error]   scala.Option.orElse(Option.scala:479)
[error]   io.getquill.parser.engine.ParserChain$OrElse$$anon$2.$anonfun$1(ParserChain.scala:46)
[error]   scala.PartialFunction$$anon$2.applyOrElse(PartialFunction.scala:379)
[error]   scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:39)
[error]     query[Product].filter(_.sku == lift("1004").toInt)
[error]                                    ^^^^^^^^^^^^
Error compiling project (Scala 3.8.0-RC1, JVM (21))
```

</details> 

Standard library is now compiled using Scala 3, which can results in a bit different trees being generated when compared with previous versions. 
In this case `augmentString(...).toX` argument is being inlined introducing previously missing `Inlined` tree.

Issue found in Scala 3 Open Community Build - [build logs](https://github.com/VirtusLab/community-build3/actions/runs/19666033780/job/56323262430)

### Solution

Add additional handling of Inlined arguments to `augmentString` methods

### Notes

Additional notes.

### Checklist

- [x] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
