### PR TITLE
perf(macros): reduce redundant implicit searches in ctx.run() pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ env:
   # See:
   #  - https://stackoverflow.com/a/73708006
   #  - https://stackoverflow.com/questions/73465937/apache-spark-3-3-0-breaks-on-java-17-with-cannot-access-class-sun-nio-ch-direct
-  JAVA_OPTS: -Xms6G -Xmx6G -XX:+UseG1GC -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -Dcommunity=false -Dquill.macro.log=false --add-exports java.base/sun.nio.ch=ALL-UNNAMED
-  JDK_JAVA_OPTIONS: -Xms6G -Xmx6G -XX:+UseG1GC -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -Dcommunity=false -Dquill.macro.log=false --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+  JAVA_OPTS: -Xms8G -Xmx8G -XX:+UseParallelGC -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -Dcommunity=false -Dquill.macro.log=false --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+  JDK_JAVA_OPTIONS: -Xms8G -Xmx8G -XX:+UseParallelGC -XX:ReservedCodeCacheSize=256m -XX:+TieredCompilation -Dcommunity=false -Dquill.macro.log=false --add-exports java.base/sun.nio.ch=ALL-UNNAMED
 
 jobs:
   build:
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [ 3.3.6 ]
+        scala: [ 3.8.1 ]
         module: [ sqltest, db, bigdata ]
 
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val isCommunityRemoteBuild =
   sys.props.getOrElse("communityRemote", "false").toBoolean
 
 lazy val scalatestVersion =
-  if (isCommunityRemoteBuild) "3.2.7" else "3.2.18"
+  if (isCommunityRemoteBuild) "3.2.7" else "3.2.19"
 
 lazy val baseModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
   `quill-sql`
@@ -86,7 +86,7 @@ val filteredModules = {
 }
 
 val zioQuillVersion = "4.8.5"
-val zioVersion = "2.1.20"
+val zioVersion = "2.1.24"
 
 lazy val `quill` =
   (project in file("."))
@@ -116,8 +116,8 @@ lazy val `quill-sql` =
         // Needs to be in-sync with both quill-engine and scalafmt-core or ClassNotFound
         // errors will happen. Even if the pprint classes are actually there
         "io.suzaku" %% "boopickle" % "1.5.0",
-        "com.lihaoyi" %% "pprint" % "0.9.3",
-        "ch.qos.logback" % "logback-classic" % "1.5.18" % Test,
+        "com.lihaoyi" %% "pprint" % "0.9.6",
+        "ch.qos.logback" % "logback-classic" % "1.5.32" % Test,
         "io.getquill" %% "quill-engine" % zioQuillVersion,
         "dev.zio" %% "zio" % zioVersion,
         ("io.getquill" %% "quill-util" % zioQuillVersion)
@@ -127,11 +127,12 @@ lazy val `quill-sql` =
             else
               Seq.empty
           }: _*),
-        "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+        "com.typesafe.scala-logging" %% "scala-logging" % "3.9.6",
         "org.scalatest" %% "scalatest" % scalatestVersion % Test,
         "org.scalatest" %% "scalatest-mustmatchers" % scalatestVersion % Test,
         "com.vladsch.flexmark" % "flexmark-all" % "0.64.8" % Test
-      )
+      ),
+      packageDoc / publishArtifact := false,
     )
 
 // Moving heavy tests to separate module so it can be compiled in parallel with others
@@ -153,14 +154,15 @@ lazy val `quill-jdbc` =
     .dependsOn(`quill-sql` % "compile->compile;test->test")
 
 ThisBuild / libraryDependencySchemes += "org.typelevel" %% "cats-effect" % "always"
+ThisBuild / libraryDependencySchemes += "dev.zio" %% "zio-json" % "always"
 lazy val `quill-doobie` =
   (project in file("quill-doobie"))
     .settings(commonSettings: _*)
     .settings(jdbcTestingSettings: _*)
     .settings(
       libraryDependencies ++= Seq(
-        "org.tpolecat" %% "doobie-core" % "1.0.0-RC5",
-        "org.tpolecat" %% "doobie-postgres" % "1.0.0-RC5" % Test
+        "org.tpolecat" %% "doobie-core" % "1.0.0-RC12",
+        "org.tpolecat" %% "doobie-postgres" % "1.0.0-RC12" % Test
       )
     )
     .dependsOn(`quill-jdbc` % "compile->compile;test->test")
@@ -171,14 +173,14 @@ lazy val `quill-caliban` =
     .settings(
       Test / fork := true,
       libraryDependencies ++= Seq(
-        "com.github.ghostdogpr" %% "caliban-quick" % "2.11.1",
+        "com.github.ghostdogpr" %% "caliban-quick" % "2.11.2",
         // Adding this to main dependencies would force users to use logback-classic for SLF4j unless the specifically remove it
         // seems to be safer to just exclude & add a commented about need for a SLF4j implementation in Docs.
-        "ch.qos.logback" % "logback-classic" % "1.5.18" % Test,
+        "ch.qos.logback" % "logback-classic" % "1.5.32" % Test,
         // Don't want to make this dependant on zio-test for the testing code so importing this here separately
         "org.scalatest" %% "scalatest" % scalatestVersion % Test,
         "org.scalatest" %% "scalatest-mustmatchers" % scalatestVersion % Test,
-        "org.postgresql" % "postgresql" % "42.7.7" % Test,
+        "org.postgresql" % "postgresql" % "42.7.10" % Test,
       )
     )
     .dependsOn(`quill-jdbc-zio` % "compile->compile")
@@ -202,8 +204,8 @@ lazy val `quill-jdbc-zio` =
     .settings(
       libraryDependencies ++= Seq(
         // Needed for PGObject in JsonExtensions but not necessary if user is not using postgres
-        "org.postgresql" % "postgresql" % "42.7.7" % "provided",
-        "dev.zio" %% "zio-json" % "0.7.44"
+        "org.postgresql" % "postgresql" % "42.7.10" % "provided",
+        "dev.zio" %% "zio-json" % "0.8.0"
       ),
       Test / runMain / fork := true,
       Test / fork := true,
@@ -264,13 +266,13 @@ lazy val commonSettings =
 lazy val jdbcTestingLibraries = Seq(
   // JDBC Libraries for testing of quill-jdbc___ contexts
   libraryDependencies ++= Seq(
-    "com.zaxxer" % "HikariCP" % "6.3.2" exclude("org.slf4j", "*"),
+    "com.zaxxer" % "HikariCP" % "6.3.3" exclude("org.slf4j", "*"),
     // In 8.0.22 error happens: Conversion from java.time.OffsetDateTime to TIMESTAMP is not supported
-    "com.mysql" % "mysql-connector-j" % "9.4.0" % Test,
-    "com.h2database" % "h2" % "2.3.232" % Test,
+    "com.mysql" % "mysql-connector-j" % "9.6.0" % Test,
+    "com.h2database" % "h2" % "2.4.240" % Test,
     // In 42.2.18 error happens: PSQLException: conversion to class java.time.OffsetTime from timetz not supported
-    "org.postgresql" % "postgresql" % "42.7.7" % Test,
-    "org.xerial" % "sqlite-jdbc" % "3.50.3.0" % Test,
+    "org.postgresql" % "postgresql" % "42.7.10" % Test,
+    "org.xerial" % "sqlite-jdbc" % "3.51.2.0" % Test,
     // In 7.1.1-jre8-preview error happens: The conversion to class java.time.OffsetDateTime is unsupported.
     "com.microsoft.sqlserver" % "mssql-jdbc" % "7.4.1.jre11" % Test,
     "com.oracle.ojdbc" % "ojdbc8" % "19.3.0.0" % Test,
@@ -290,7 +292,7 @@ lazy val basicSettings = Seq(
   excludeDependencies ++= Seq(
     ExclusionRule("org.scala-lang.modules", "scala-collection-compat_2.13")
   ),
-  scalaVersion := "3.3.6",
+  scalaVersion := "3.8.1",
   // The -e option is the 'error' report of ScalaTest. We want it to only make a log
   // of the failed tests once all tests are done, the regular -o log shows everything else.
   // Test / testOptions ++= Seq(
@@ -299,13 +301,16 @@ lazy val basicSettings = Seq(
   //   //Tests.Argument(TestFrameworks.ScalaTest, "-u", "junits")
   //   //Tests.Argument(TestFrameworks.ScalaTest, "-h", "testresults")
   // ),
+  usePipelining := true,
   scalacOptions ++= Seq(
     "-language:implicitConversions", "-explain",
     // See https://docs.scala-lang.org/scala3/guides/migration/tooling-syntax-rewriting.html
     "-no-indent",
-    "-release:11",
+    "-release:17",
+    "-source:3.3", // Suppress `implicit` keyword deprecation warnings for gradual migration
   ),
-  javacOptions := Seq("-source", "11", "-target", "11"),
+  javacOptions := Seq("-source", "17", "-target", "17"),
+  scalacOptions ++= (if (sys.props.getOrElse("profile", "false").toBoolean) Seq("-Vprofile") else Seq.empty),
 )
 
 // force redraft

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.4
+sbt.version=1.12.4

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Decoders.scala
@@ -61,4 +61,20 @@ trait Decoders extends CassandraRowContext with EncodingDsl with CollectionDecod
   implicit val timestampDecoder: Decoder[Instant] = decoder(_.getInstant)
   implicit val cassandraLocalTimeDecoder: Decoder[LocalTime] = decoder(_.getLocalTime)
   implicit val cassandraLocalDateDecoder: Decoder[LocalDate] = decoder(_.getLocalDate)
+
+  // Pre-materialized Option decoders to short-circuit implicit search
+  implicit val optionStringDecoder: Decoder[Option[String]] = optionDecoder[String]
+  implicit val optionBigDecimalDecoder: Decoder[Option[BigDecimal]] = optionDecoder[BigDecimal]
+  implicit val optionBooleanDecoder: Decoder[Option[Boolean]] = optionDecoder[Boolean]
+  implicit val optionByteDecoder: Decoder[Option[Byte]] = optionDecoder[Byte]
+  implicit val optionShortDecoder: Decoder[Option[Short]] = optionDecoder[Short]
+  implicit val optionIntDecoder: Decoder[Option[Int]] = optionDecoder[Int]
+  implicit val optionLongDecoder: Decoder[Option[Long]] = optionDecoder[Long]
+  implicit val optionFloatDecoder: Decoder[Option[Float]] = optionDecoder[Float]
+  implicit val optionDoubleDecoder: Decoder[Option[Double]] = optionDecoder[Double]
+  implicit val optionByteArrayDecoder: Decoder[Option[Array[Byte]]] = optionDecoder[Array[Byte]]
+  implicit val optionUuidDecoder: Decoder[Option[UUID]] = optionDecoder[UUID]
+  implicit val optionTimestampDecoder: Decoder[Option[Instant]] = optionDecoder[Instant]
+  implicit val optionLocalTimeDecoder: Decoder[Option[LocalTime]] = optionDecoder[LocalTime]
+  implicit val optionLocalDateDecoder: Decoder[Option[LocalDate]] = optionDecoder[LocalDate]
 }

--- a/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/context/cassandra/encoding/Encoders.scala
@@ -79,4 +79,20 @@ with UdtEncoding {
   implicit val timestampEncoder: Encoder[Instant] = encoder(_.setInstant)
   implicit val cassandraLocalTimeEncoder: Encoder[LocalTime] = encoder(_.setLocalTime)
   implicit val cassandraLocalDateEncoder: Encoder[LocalDate] = encoder(_.setLocalDate)
+
+  // Pre-materialized Option encoders to short-circuit implicit search
+  implicit val optionStringEncoder: Encoder[Option[String]] = optionEncoder[String]
+  implicit val optionBigDecimalEncoder: Encoder[Option[BigDecimal]] = optionEncoder[BigDecimal]
+  implicit val optionBooleanEncoder: Encoder[Option[Boolean]] = optionEncoder[Boolean]
+  implicit val optionByteEncoder: Encoder[Option[Byte]] = optionEncoder[Byte]
+  implicit val optionShortEncoder: Encoder[Option[Short]] = optionEncoder[Short]
+  implicit val optionIntEncoder: Encoder[Option[Int]] = optionEncoder[Int]
+  implicit val optionLongEncoder: Encoder[Option[Long]] = optionEncoder[Long]
+  implicit val optionFloatEncoder: Encoder[Option[Float]] = optionEncoder[Float]
+  implicit val optionDoubleEncoder: Encoder[Option[Double]] = optionEncoder[Double]
+  implicit val optionByteArrayEncoder: Encoder[Option[Array[Byte]]] = optionEncoder[Array[Byte]]
+  implicit val optionUuidEncoder: Encoder[Option[UUID]] = optionEncoder[UUID]
+  implicit val optionTimestampEncoder: Encoder[Option[Instant]] = optionEncoder[Instant]
+  implicit val optionLocalTimeEncoder: Encoder[Option[LocalTime]] = optionEncoder[LocalTime]
+  implicit val optionLocalDateEncoder: Encoder[Option[LocalDate]] = optionEncoder[LocalDate]
 }

--- a/quill-doobie/src/main/scala/io/getquill/doobie/DoobieContextBase.scala
+++ b/quill-doobie/src/main/scala/io/getquill/doobie/DoobieContextBase.scala
@@ -91,9 +91,10 @@ trait DoobieContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   ): ConnectionIO[List[A]] =
     HC.prepareStatement(sql) {
       useConnection { implicit connection =>
+        implicit val read: Read[A] = extractorToRead(extractor)
         prepareAndLog(sql, prepare) *>
           HPS.executeQuery {
-            HRS.list(extractor)
+            HRS.list[A]
           }
       }
     }
@@ -108,9 +109,10 @@ trait DoobieContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   ): ConnectionIO[A] =
     HC.prepareStatement(sql) {
       useConnection { implicit connection =>
+        implicit val read: Read[A] = extractorToRead(extractor)
         prepareAndLog(sql, prepare) *>
           HPS.executeQuery {
-            HRS.getUnique(extractor)
+            HRS.getUnique[A]
           }
       }
     }
@@ -126,12 +128,14 @@ trait DoobieContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   ): Stream[ConnectionIO, A] =
     for {
       connection <- Stream.eval(FC.raw(identity))
-      result <-
-        HC.stream(
+      result <- {
+        implicit val read: Read[A] = extractorToRead(extractor)(connection)
+        HC.stream[A](
           sql,
           prepareAndLog(sql, prepare)(connection),
           fetchSize.getOrElse(DefaultChunkSize),
-        )(extractorToRead(extractor)(connection))
+        )
+      }
     } yield result
 
   override def executeAction(
@@ -175,9 +179,10 @@ trait DoobieContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   ): ConnectionIO[List[A]] =
     prepareConnections[List[A]](returningBehavior)(sql) {
       useConnection { implicit connection =>
+        implicit val read: Read[A] = extractorToRead(extractor)
         prepareAndLog(sql, prepare) *>
           FPS.executeUpdate *>
-          HPS.getGeneratedKeys[List[A]](HRS.list(extractor))
+          HPS.getGeneratedKeys[List[A]](HRS.list[A])
       }
     }
 
@@ -219,11 +224,12 @@ trait DoobieContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
       prepareConnections(returningBehavior)(sql) {
 
         useConnection { implicit connection =>
+          implicit val read: Read[A] = extractorToRead(extractor)
           for {
             _ <- FPS.delay(log.underlying.debug("Batch: {}", sql))
             _ <- preps.traverse(prepareBatchAndLog(sql, _) *> FPS.addBatch)
             _ <- HPS.executeBatch
-            r <- HPS.getGeneratedKeys(HRS.list(extractor))
+            r <- HPS.getGeneratedKeys(HRS.list[A])
           } yield r
         }
       }
@@ -234,7 +240,12 @@ trait DoobieContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
     ex: Extractor[A]
   )(
     implicit connection: Connection
-  ): Read[A] = new Read[A](Nil, (rs, _) => ex(rs, connection))
+  ): Read[A] = new Read[A] {
+    override def unsafeGet(rs: java.sql.ResultSet, startIdx: Int): A = ex(rs, connection)
+    override def gets = Nil
+    override def toOpt: Read[Option[A]] = this.map(a => Option(a))
+    override def length: Int = 0
+  }
 
   // Nothing to do here.
   override def close(): Unit = ()

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Decoders.scala
@@ -74,6 +74,21 @@ trait Decoders {
   implicit val dateDecoder: Decoder[util.Date] =
     decoder((index, row, session) =>
       new util.Date(row.getTimestamp(index, Calendar.getInstance(dateTimeZone)).getTime))
+
+  // Pre-materialized Option decoders to short-circuit implicit search
+  implicit val optionStringDecoder: Decoder[Option[String]] = optionDecoder[String]
+  implicit val optionBigDecimalDecoder: Decoder[Option[BigDecimal]] = optionDecoder[BigDecimal]
+  implicit val optionByteDecoder: Decoder[Option[Byte]] = optionDecoder[Byte]
+  implicit val optionShortDecoder: Decoder[Option[Short]] = optionDecoder[Short]
+  implicit val optionIntDecoder: Decoder[Option[Int]] = optionDecoder[Int]
+  implicit val optionLongDecoder: Decoder[Option[Long]] = optionDecoder[Long]
+  implicit val optionFloatDecoder: Decoder[Option[Float]] = optionDecoder[Float]
+  implicit val optionDoubleDecoder: Decoder[Option[Double]] = optionDecoder[Double]
+  implicit val optionByteArrayDecoder: Decoder[Option[Array[Byte]]] = optionDecoder[Array[Byte]]
+  implicit val optionDateDecoder: Decoder[Option[util.Date]] = optionDecoder[util.Date]
+  implicit val optionSqlDateDecoder: Decoder[Option[java.sql.Date]] = optionDecoder[java.sql.Date]
+  implicit val optionSqlTimeDecoder: Decoder[Option[java.sql.Time]] = optionDecoder[java.sql.Time]
+  implicit val optionSqlTimestampDecoder: Decoder[Option[java.sql.Timestamp]] = optionDecoder[java.sql.Timestamp]
 }
 
 trait BasicTimeDecoders extends Decoders {

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/Encoders.scala
@@ -82,6 +82,21 @@ trait Encoders extends EncodingDsl {
   implicit val dateEncoder: Encoder[util.Date] =
     encoder(Types.TIMESTAMP, (index, value, row) =>
       row.setTimestamp(index, new sql.Timestamp(value.getTime), Calendar.getInstance(dateTimeZone)))
+
+  // Pre-materialized Option encoders to short-circuit implicit search
+  implicit val optionStringEncoder: Encoder[Option[String]] = optionEncoder[String]
+  implicit val optionBigDecimalEncoder: Encoder[Option[BigDecimal]] = optionEncoder[BigDecimal]
+  implicit val optionByteEncoder: Encoder[Option[Byte]] = optionEncoder[Byte]
+  implicit val optionShortEncoder: Encoder[Option[Short]] = optionEncoder[Short]
+  implicit val optionIntEncoder: Encoder[Option[Int]] = optionEncoder[Int]
+  implicit val optionLongEncoder: Encoder[Option[Long]] = optionEncoder[Long]
+  implicit val optionFloatEncoder: Encoder[Option[Float]] = optionEncoder[Float]
+  implicit val optionDoubleEncoder: Encoder[Option[Double]] = optionEncoder[Double]
+  implicit val optionByteArrayEncoder: Encoder[Option[Array[Byte]]] = optionEncoder[Array[Byte]]
+  implicit val optionDateEncoder: Encoder[Option[util.Date]] = optionEncoder[util.Date]
+  implicit val optionSqlDateEncoder: Encoder[Option[java.sql.Date]] = optionEncoder[java.sql.Date]
+  implicit val optionSqlTimeEncoder: Encoder[Option[java.sql.Time]] = optionEncoder[java.sql.Time]
+  implicit val optionSqlTimestampEncoder: Encoder[Option[java.sql.Timestamp]] = optionEncoder[java.sql.Timestamp]
 }
 
 trait BasicTimeEncoders extends Encoders {

--- a/quill-sql/src/main/scala/io/getquill/Dsl.scala
+++ b/quill-sql/src/main/scala/io/getquill/Dsl.scala
@@ -45,6 +45,17 @@ extension (str: String) {
 inline def query[T]: EntityQuery[T] = ${ QueryMacro[T] }
 inline def select[T]: Query[T] = ${ QueryMacro[T] }
 
+// NamedTuple-based query API (Scala 3.7+) — uses Selectable + NamedTuple.From[T]
+// for type-level schema derivation instead of macro AST inspection.
+// Produces identical SQL to query[T] but with faster compilation.
+inline def typedQuery[T]: io.getquill.record.TypedEntityQuery[T] =
+  ${ io.getquill.record.TypedQueryMacro[T] }
+
+// Implicit conversion: TypedEntityQuery[T] -> Quoted[EntityQuery[T]] so it can be
+// passed directly to ctx.run() without explicit .toQuoted call
+implicit inline def typedQueryToQuoted[T](inline teq: io.getquill.record.TypedEntityQuery[T]): Quoted[EntityQuery[T]] =
+  teq.toQuoted
+
 def max[A](a: A): A = NonQuotedException()
 def min[A](a: A): A = NonQuotedException()
 def count[A](a: A): A = NonQuotedException()

--- a/quill-sql/src/main/scala/io/getquill/context/mirror/MirrorDecoders.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/mirror/MirrorDecoders.scala
@@ -55,4 +55,19 @@ trait MirrorDecoders extends EncodingDsl {
   implicit val dateDecoder: Decoder[Date] = decoder[Date]
   implicit val localDateDecoder: Decoder[LocalDate] = decoder[LocalDate]
   implicit val uuidDecoder: Decoder[UUID] = decoder[UUID]
+
+  // Pre-materialized Option decoders to short-circuit implicit search
+  implicit val optionStringDecoder: Decoder[Option[String]] = optionDecoder[String]
+  implicit val optionBigDecimalDecoder: Decoder[Option[BigDecimal]] = optionDecoder[BigDecimal]
+  implicit val optionBooleanDecoder: Decoder[Option[Boolean]] = optionDecoder[Boolean]
+  implicit val optionByteDecoder: Decoder[Option[Byte]] = optionDecoder[Byte]
+  implicit val optionShortDecoder: Decoder[Option[Short]] = optionDecoder[Short]
+  implicit val optionIntDecoder: Decoder[Option[Int]] = optionDecoder[Int]
+  implicit val optionLongDecoder: Decoder[Option[Long]] = optionDecoder[Long]
+  implicit val optionFloatDecoder: Decoder[Option[Float]] = optionDecoder[Float]
+  implicit val optionDoubleDecoder: Decoder[Option[Double]] = optionDecoder[Double]
+  implicit val optionByteArrayDecoder: Decoder[Option[Array[Byte]]] = optionDecoder[Array[Byte]]
+  implicit val optionDateDecoder: Decoder[Option[Date]] = optionDecoder[Date]
+  implicit val optionLocalDateDecoder: Decoder[Option[LocalDate]] = optionDecoder[LocalDate]
+  implicit val optionUuidDecoder: Decoder[Option[UUID]] = optionDecoder[UUID]
 }

--- a/quill-sql/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/mirror/MirrorEncoders.scala
@@ -45,4 +45,19 @@ trait MirrorEncoders extends EncodingDsl {
   implicit val localDateEncoder: Encoder[LocalDate] = encoder[LocalDate]
   implicit val uuidEncoder: Encoder[UUID] = encoder[UUID]
   implicit def nullEncoder: Encoder[Null] = encoder[Null]
+
+  // Pre-materialized Option encoders to short-circuit implicit search
+  implicit val optionStringEncoder: Encoder[Option[String]] = optionEncoder[String]
+  implicit val optionBigDecimalEncoder: Encoder[Option[BigDecimal]] = optionEncoder[BigDecimal]
+  implicit val optionBooleanEncoder: Encoder[Option[Boolean]] = optionEncoder[Boolean]
+  implicit val optionByteEncoder: Encoder[Option[Byte]] = optionEncoder[Byte]
+  implicit val optionShortEncoder: Encoder[Option[Short]] = optionEncoder[Short]
+  implicit val optionIntEncoder: Encoder[Option[Int]] = optionEncoder[Int]
+  implicit val optionLongEncoder: Encoder[Option[Long]] = optionEncoder[Long]
+  implicit val optionFloatEncoder: Encoder[Option[Float]] = optionEncoder[Float]
+  implicit val optionDoubleEncoder: Encoder[Option[Double]] = optionEncoder[Double]
+  implicit val optionByteArrayEncoder: Encoder[Option[Array[Byte]]] = optionEncoder[Array[Byte]]
+  implicit val optionDateEncoder: Encoder[Option[Date]] = optionEncoder[Date]
+  implicit val optionLocalDateEncoder: Encoder[Option[LocalDate]] = optionEncoder[LocalDate]
+  implicit val optionUuidEncoder: Encoder[Option[UUID]] = optionEncoder[UUID]
 }

--- a/quill-sql/src/main/scala/io/getquill/generic/ElaborateStructure.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/ElaborateStructure.scala
@@ -15,6 +15,7 @@ import io.getquill.metaprog.TypeExtensions._
 import io.getquill.generic.DecodingType
 import io.getquill.util.Format
 import scala.annotation.tailrec
+import scala.collection.mutable
 import io.getquill.ast.External.Source
 import zio.Chunk
 import io.getquill.metaprog.Extractors
@@ -269,25 +270,27 @@ object ElaborateStructure {
       }
     }
 
-    private[getquill] def ofProduct[T: Type](side: ElaborationSide, baseName: String = "notused", udtBehavior: UdtBehavior = UdtBehavior.Leaf)(using Quotes) =
-      base[T](Term(baseName, Branch), side, udtBehavior)
+    private[getquill] def ofProduct[T: Type](side: ElaborationSide, baseName: String = "notused", udtBehavior: UdtBehavior = UdtBehavior.Leaf)(using Quotes) = {
+      val leafCache = mutable.Map.empty[String, Boolean]
+      base[T](Term(baseName, Branch), side, udtBehavior, leafCache)
+    }
 
   } // end Term
 
   /** Go through all possibilities that the element might be and collect their fields */
-  def collectFields[Fields, Types](node: Term, fieldsTup: Type[Fields], typesTup: Type[Types], side: ElaborationSide)(using Quotes): List[Term] = {
+  def collectFields[Fields, Types](node: Term, fieldsTup: Type[Fields], typesTup: Type[Types], side: ElaborationSide, leafCache: mutable.Map[String, Boolean] = mutable.Map.empty)(using Quotes): List[Term] = {
     import quotes.reflect.{Term => QTerm, _}
 
     (fieldsTup, typesTup) match {
       case ('[field *: fields], '[tpe *: types]) if Type.of[tpe].isProduct =>
-        base[tpe](node, side) :: collectFields(node, Type.of[fields], Type.of[types], side)
+        base[tpe](node, side, leafCache = leafCache) :: collectFields(node, Type.of[fields], Type.of[types], side, leafCache)
       case (_, '[EmptyTuple]) => Nil
       case _                  => report.throwError("Cannot Derive Sum during Type Flattening of Expression:\n" + (fieldsTup, typesTup))
     }
   }
 
   @tailrec
-  def flatten[Fields, Types](node: Term, fieldsTup: Type[Fields], typesTup: Type[Types], side: ElaborationSide, accum: List[Term] = List())(using Quotes): List[Term] = {
+  def flatten[Fields, Types](node: Term, fieldsTup: Type[Fields], typesTup: Type[Types], side: ElaborationSide, accum: List[Term] = List(), leafCache: mutable.Map[String, Boolean] = mutable.Map.empty)(using Quotes): List[Term] = {
     import quotes.reflect.{Term => QTerm, _}
 
     def constValue[T: Type]: String =
@@ -309,27 +312,23 @@ object ElaborateStructure {
           case '[tpe] =>
             if (Type.of[tpe].isProduct) {
               val childTerm = Term(Type.of[field].constValue, Branch, optional = true)
-              // println(s"------ Optional field expansion ${Type.of[field].constValue.toString}:${TypeRepr.of[tpe].show} is a product ----------")
-              val baseTerm = base[tpe](childTerm, side)
-              flatten(node, Type.of[fields], Type.of[types], side, baseTerm +: accum)
+              val baseTerm = base[tpe](childTerm, side, leafCache = leafCache)
+              flatten(node, Type.of[fields], Type.of[types], side, baseTerm +: accum, leafCache)
             }
             else {
               val childTerm = Term(Type.of[field].constValue, Leaf, optional = true)
-              // println(s"------ Optional field expansion ${Type.of[field].constValue.toString}:${TypeRepr.of[tpe].show} is a Leaf ----------")
-              flatten(node, Type.of[fields], Type.of[types], side, childTerm +: accum)
+              flatten(node, Type.of[fields], Type.of[types], side, childTerm +: accum, leafCache)
             }
         }
 
       case ('[field *: fields], '[tpe *: types]) if Type.of[tpe].isProduct && Type.of[tpe].notOption =>
         val childTerm = Term(Type.of[field].constValue, Branch)
-        // println(s"------ Non-Optional field expansion ${Type.of[field].constValue.toString}:${TypeRepr.of[tpe].show} is a product ----------")
-        val baseTerm = base[tpe](childTerm, side)
-        flatten(node, Type.of[fields], Type.of[types], side, baseTerm +: accum)
+        val baseTerm = base[tpe](childTerm, side, leafCache = leafCache)
+        flatten(node, Type.of[fields], Type.of[types], side, baseTerm +: accum, leafCache)
 
       case ('[field *: fields], '[tpe *: types]) if Type.of[tpe].notOption =>
         val childTerm = Term(Type.of[field].constValue, Leaf)
-        // println(s"------ Non-Optional field expansion ${Type.of[field].constValue.toString}:${TypeRepr.of[tpe].show} is a Leaf ----------")
-        flatten(node, Type.of[fields], Type.of[types], side, childTerm +: accum)
+        flatten(node, Type.of[fields], Type.of[types], side, childTerm +: accum, leafCache)
 
       case (_, '[EmptyTuple]) => accum.reverse
 
@@ -361,7 +360,7 @@ object ElaborateStructure {
    * That means that we need to know whether to look for an encoder as opposed to a decoder
    * when trying to wrap this type.
    */
-  def base[T: Type](term: Term, side: ElaborationSide, udtBehavior: UdtBehavior = UdtBehavior.Leaf)(using Quotes): Term = {
+  def base[T: Type](term: Term, side: ElaborationSide, udtBehavior: UdtBehavior = UdtBehavior.Leaf, leafCache: mutable.Map[String, Boolean] = mutable.Map.empty)(using Quotes): Term = {
     import quotes.reflect.{Term => QTerm, _}
 
     // for errors/warnings
@@ -371,31 +370,26 @@ object ElaborateStructure {
         case ElaborationSide.Decoding => "decodeable"
       }
 
+    // Fast-path: known leaf types (String, Int, etc.) skip expensive Expr.summon
     val isAutomaticLeaf =
-      side match {
-        // Not sure why the UDT part is needed since it shuold always have a GenericEncoder/Decoder anyway
-        case _ if (TypeRepr.of[T] <:< TypeRepr.of[io.getquill.Udt]) =>
-          // println(s"------- TREATING UDT as Leaf ${Format.TypeOf[T]}")
-          // If we are elaborating a UDT and are told to wrap normally, make sure that this is done
-          // even if an encoder exists for the UDT. Otherwise, automatically treat the UDT as a Leaf entity
-          // (since an encoder for it should have been derived by the macro that used UdtBehavior.Derive)
-          udtBehavior match {
-            case UdtBehavior.Leaf   => true
-            case UdtBehavior.Derive => false
+      if (Type.of[T].isKnownLeaf)
+        true
+      else {
+        val typeKey = Type.show[T]
+        leafCache.getOrElseUpdate(typeKey, {
+          side match {
+            case _ if (TypeRepr.of[T] <:< TypeRepr.of[io.getquill.Udt]) =>
+              udtBehavior match {
+                case UdtBehavior.Leaf   => true
+                case UdtBehavior.Derive => false
+              }
+            case ElaborationSide.Encoding =>
+              Expr.summon[GenericEncoder[T, _, _]].isDefined
+            case ElaborationSide.Decoding =>
+              Expr.summon[GenericDecoder[_, _, T, DecodingType.Specific]].isDefined
           }
-        case ElaborationSide.Encoding =>
-          // println(s"------- ALREDY EXISTS Encoder for ${Format.TypeOf[T]}")
-          Expr.summon[GenericEncoder[T, _, _]].isDefined
-        case ElaborationSide.Decoding =>
-          // println(s"------- ALREDY EXISTS Decoder for ${Format.TypeOf[T]}")
-          Expr.summon[GenericDecoder[_, _, T, DecodingType.Specific]].isDefined
+        })
       }
-
-    // TODO Back here. Should have a input arg that asks whether elaboration is
-    //      on the encoding or on the decoding side.
-    // Expr.summon[GenericDecoder[_, T, DecodingType.Generic]] match
-    //   case Some(v) => println(s"**** Find Generic Decoder for ${io.getquill.util.Format.TypeOf[T]}: ${v.show}")
-    //   case None => println(s"**** Not found Generic Decoder for ${io.getquill.util.Format.TypeOf[T]}")
 
     // See if there is a generic encoder for it. Since there are no derived generic encoders,
     // (only Generic Decoders), it is a good way to tell if something is a value type or not.
@@ -409,12 +403,12 @@ object ElaborateStructure {
           // Otherwise, recursively summon fields
           ev match {
             case '{ $m: Mirror.ProductOf[T] { type MirroredElemLabels = elementLabels; type MirroredElemTypes = elementTypes } } =>
-              val children = flatten(term, Type.of[elementLabels], Type.of[elementTypes], side)
+              val children = flatten(term, Type.of[elementLabels], Type.of[elementTypes], side, leafCache = leafCache)
               term.withChildren(children)
             // TODO Make sure you can summon a ColumnResolver if there is a SumMirror, otherwise this kind of decoding should be impossible
             case '{ $m: Mirror.SumOf[T] { type MirroredElemLabels = elementLabels; type MirroredElemTypes = elementTypes } } =>
               // Find field infos (i.e. Term objects) for all potential types that this coproduct could be
-              val alternatives = collectFields(term, Type.of[elementLabels], Type.of[elementTypes], side)
+              val alternatives = collectFields(term, Type.of[elementLabels], Type.of[elementTypes], side, leafCache)
               // Then merge them together to get one term representing all of their fields types.
               // Say you have a coproduct Shape -> (Square(width), Rectangle(width,height), Circle(radius))
               // You would get Term(width, height, radius)
@@ -430,7 +424,8 @@ object ElaborateStructure {
   }
 
   private def productized[T: Type](side: ElaborationSide, baseName: String = "x")(using Quotes): Ast = {
-    val lifted = base[T](Term(baseName, Branch), side).toAst
+    val leafCache = mutable.Map.empty[String, Boolean]
+    val lifted = base[T](Term(baseName, Branch), side, leafCache = leafCache).toAst
     val insert =
       if (lifted.length == 1)
         lifted.head._1
@@ -441,7 +436,8 @@ object ElaborateStructure {
   }
 
   def ofProductType[T: Type](baseName: String, side: ElaborationSide)(using Quotes): List[Ast] = {
-    val expanded = base[T](Term(baseName, Branch), side)
+    val leafCache = mutable.Map.empty[String, Boolean]
+    val expanded = base[T](Term(baseName, Branch), side, leafCache = leafCache)
     expanded.toAst.map(_._1)
   }
 

--- a/quill-sql/src/main/scala/io/getquill/generic/EncodingDsl.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/EncodingDsl.scala
@@ -4,6 +4,7 @@ import scala.reflect.ClassTag
 import scala.quoted._
 import scala.deriving._
 import scala.compiletime.{erasedValue, summonFrom}
+import scala.annotation.implicitNotFound
 import io.getquill.MappedEncoding
 import io.getquill.generic.DecodingType
 
@@ -81,10 +82,12 @@ trait EncodingDsl extends LowPriorityImplicits { self => // extends LowPriorityI
 
   // For: Mapped := Foo(value: String), Base := String
   // Encoding follows: (MappedEncoding(Foo) => String) <=(contramap)= Encoder(Foo)
+  @implicitNotFound("Cannot find a mapped encoder for type ${Mapped}. Ensure a MappedEncoding[${Mapped}, ${Base}] and an Encoder[${Base}] are in scope.")
   implicit def mappedEncoder[Mapped, Base](implicit mapped: MappedEncoding[Mapped, Base], encoder: Encoder[Base]): Encoder[Mapped]
 
   // For: Base := String, Mapped := Foo(value: String)
   // Decoding follows: (MappedEncoding(String) => Foo) =(map)=> Decoder(Foo)
+  @implicitNotFound("Cannot find a mapped decoder for type ${Mapped}. Ensure a MappedEncoding[${Base}, ${Mapped}] and a Decoder[${Base}] are in scope.")
   implicit def mappedDecoder[Base, Mapped](implicit mapped: MappedEncoding[Base, Mapped], decoder: Decoder[Base]): Decoder[Mapped]
 
   protected def mappedBaseEncoder[Mapped, Base](mapped: MappedEncoding[Mapped, Base], encoder: EncoderMethod[Base]): EncoderMethod[Mapped] =

--- a/quill-sql/src/main/scala/io/getquill/generic/GenericDecoder.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/GenericDecoder.scala
@@ -5,6 +5,7 @@ import scala.reflect.classTag
 import scala.quoted._
 import scala.deriving._
 import scala.compiletime.{erasedValue, constValue, summonFrom, summonInline}
+import scala.collection.mutable
 import io.getquill.metaprog.TypeExtensions._
 import io.getquill.util.Format
 import scala.annotation.tailrec
@@ -29,30 +30,40 @@ trait GenericRowTyper[ResultRow, Co] {
 }
 
 object Summon {
-  def nullChecker[ResultRow: Type, Session: Type](index: Expr[Int], resultRow: Expr[ResultRow])(using Quotes): Expr[Boolean] = {
+  private val NullCheckerCacheKey = "__nullchecker__"
+  def nullChecker[ResultRow: Type, Session: Type](index: Expr[Int], resultRow: Expr[ResultRow], nullCheckerCache: mutable.Map[String, Option[Expr[_]]] = mutable.Map.empty)(using Quotes): Expr[Boolean] = {
     import quotes.reflect._
-    Expr.summon[GenericNullChecker[ResultRow, Session]] match {
-      case Some(nullChecker) => '{ $nullChecker($index, $resultRow) }
+    val nc = nullCheckerCache.getOrElseUpdate(NullCheckerCacheKey,
+      Expr.summon[GenericNullChecker[ResultRow, Session]]
+    )
+    nc match {
+      case Some(nullChecker) =>
+        val typedNc = nullChecker.asExprOf[GenericNullChecker[ResultRow, Session]]
+        '{ $typedNc($index, $resultRow) }
       case None              =>
-        // TODO Maybe check the session type and based on what it is, say "Cannot summon a JDBC null-chercker..."
         report.throwError(s"Cannot find a null-checker for the session type ${Format.TypeOf[Session]} (whose result-row type is: ${Format.TypeOf[ResultRow]})")
     }
   }
 
-  def decoder[ResultRow: Type, Session: Type, T: Type](index: Expr[Int], resultRow: Expr[ResultRow], session: Expr[Session])(using Quotes): Option[Expr[T]] = {
+  def decoder[ResultRow: Type, Session: Type, T: Type](index: Expr[Int], resultRow: Expr[ResultRow], session: Expr[Session], decoderCache: mutable.Map[String, Option[Expr[_]]] = mutable.Map.empty)(using Quotes): Option[Expr[T]] = {
     import quotes.reflect.{Term => QTerm, _}
-    // Try to summon a specific decoder, if it's not there, summon a generic one
-    Expr.summon[GenericDecoder[ResultRow, Session, T, DecodingType.Specific]] match {
+    val typeKey = Type.show[T]
+    // Look up cached decoder expr for this type, or summon and cache it
+    val cachedDecoder = decoderCache.getOrElseUpdate(typeKey,
+      Expr.summon[GenericDecoder[ResultRow, Session, T, DecodingType.Specific]]
+    )
+    cachedDecoder match {
       case Some(decoder) =>
-        Some('{ $decoder($index, $resultRow, $session) })
+        val typedDecoder = decoder.asExprOf[GenericDecoder[ResultRow, Session, T, DecodingType.Specific]]
+        Some('{ $typedDecoder($index, $resultRow, $session) })
       case None =>
         None
     }
   }
 
-  def decoderOrFail[ResultRow: Type, Session: Type, T: Type](index: Expr[Int], resultRow: Expr[ResultRow], session: Expr[Session])(using Quotes): Expr[T] = {
+  def decoderOrFail[ResultRow: Type, Session: Type, T: Type](index: Expr[Int], resultRow: Expr[ResultRow], session: Expr[Session], decoderCache: mutable.Map[String, Option[Expr[_]]] = mutable.Map.empty)(using Quotes): Expr[T] = {
     import quotes.reflect._
-    decoder[ResultRow, Session, T](index, resultRow, session) match {
+    decoder[ResultRow, Session, T](index, resultRow, session, decoderCache) match {
       case Some(value) => value
       case None =>
         println(s"WARNING Could not summon a decoder for the type: ${io.getquill.util.Format.TypeOf[T]}")
@@ -82,42 +93,37 @@ object GenericDecoder {
       index: Int,
       baseIndex: Expr[Int],
       resultRow: Expr[ResultRow],
-      session: Expr[Session]
+      session: Expr[Session],
+      decoderCache: mutable.Map[String, Option[Expr[_]]] = mutable.Map.empty
   )(fieldsTup: Type[Fields], typesTup: Type[Types], accum: List[FlattenData] = List())(using Quotes): List[FlattenData] = {
     import quotes.reflect.{Term => QTerm, _}
 
     (fieldsTup, typesTup) match {
+      // Fast-path: known leaf types (String, Int, etc.) are guaranteed to have decoders — skip expensive Expr.summon guard
+      case ('[field *: fields], '[tpe *: types]) if Type.of[tpe].isKnownLeaf =>
+        val fieldValue = Type.of[field].constValue
+        val possiblyShiftedIndex = tryResolveIndex[ResultRow]('{ $baseIndex + ${ Expr(index) } }, resultRow, fieldValue)
+        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session, possiblyShiftedIndex, decoderCache)
+        val nextIndex = index + 1
+        flatten[ResultRow, Session, fields, types](nextIndex, baseIndex, resultRow, session, decoderCache)(Type.of[fields], Type.of[types], result +: accum)
+
       // Check if the field has a specific user-defined encoder for it e.g. Person(name: String) (i.e. since there is a String encoder)
       // or if it is an embedded entity e.g. Person(name: Name, age: Int) where Name is `case class Name(first: String, last: String)`.
-      // TODO summoning `GenericDecoder[ResultRow, T, Session, DecodingType.Specific]` here twice, once in the if statement,
-      // then later in summonAndDecode. This can potentially be improved i.e. it can be summoned just once and reused.
-      case ('[field *: fields], '[tpe *: types]) if Expr.summon[GenericDecoder[ResultRow, Session, tpe, DecodingType.Specific]].isEmpty =>
+      case ('[field *: fields], '[tpe *: types]) if Summon.decoder[ResultRow, Session, tpe]('{ $baseIndex + ${ Expr(index) } }, resultRow, session, decoderCache).isEmpty =>
         // Get the field class as an actual string, on the mirror itself it's stored as a type
         val fieldValue = Type.of[field].constValue
-        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session)
+        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session, None, decoderCache)
         // Say we are on Person(id(c1): Int, name: Name(first(c2): String, last(c3): String), age(c4): Int)
         // if we are on the at the last `age` field the last recursion of the `name` field should have bumped our index 3
         val nextIndex = result.index + 1
-        flatten[ResultRow, Session, fields, types](nextIndex, baseIndex, resultRow, session)(Type.of[fields], Type.of[types], result +: accum)
+        flatten[ResultRow, Session, fields, types](nextIndex, baseIndex, resultRow, session, decoderCache)(Type.of[fields], Type.of[types], result +: accum)
 
       case ('[field *: fields], '[tpe *: types]) =>
         val fieldValue = Type.of[field].constValue
-        // If we are in a product that is actually a variant of a co-product, maybe the column needs to be shifted
-        // because when decoding we don't care about all the columns. For example,
-        //   sealed trait Shape
-        //   case class Square(length: Int, width: Int) extends Shape
-        //   case class Circle(radius: Int) extends Shape
-        //   In that case `tpe` here will be Square/Circle
-        // In this case we need to decode ResultRow(shapeType, raidus, length, width) but
-        // However, the Square shape will only know about columns List(length, width)
-        // the Circle shape will only know about columns: List(radius)
-        // The column resolver looks at the expected columns and figures out what the real index is supposed to be.
-        // For example if the index is 0, the ColumnResolver will look at Square and resolve that index to the
-        // `length` column whose actual index (of ResultRow) as seen above is 3.
         val possiblyShiftedIndex = tryResolveIndex[ResultRow]('{ $baseIndex + ${ Expr(index) } }, resultRow, fieldValue)
-        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session, possiblyShiftedIndex)
+        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session, possiblyShiftedIndex, decoderCache)
         val nextIndex = index + 1
-        flatten[ResultRow, Session, fields, types](nextIndex, baseIndex, resultRow, session)(Type.of[fields], Type.of[types], result +: accum)
+        flatten[ResultRow, Session, fields, types](nextIndex, baseIndex, resultRow, session, decoderCache)(Type.of[fields], Type.of[types], result +: accum)
 
       case (_, '[EmptyTuple]) => accum
 
@@ -131,42 +137,46 @@ object GenericDecoder {
       index: Int,
       baseIndex: Expr[Int],
       resultRow: Expr[ResultRow],
-      session: Expr[Session]
+      session: Expr[Session],
+      decoderCache: mutable.Map[String, Option[Expr[_]]] = mutable.Map.empty
   )(accum: List[FlattenData] = List())(using Quotes): List[FlattenData] = {
     import quotes.reflect.{Term => QTerm, _}
 
     Type.of[Types] match {
-      case '[tpe *: types] if Expr.summon[GenericDecoder[ResultRow, Session, tpe, DecodingType.Specific]].isEmpty =>
-        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session)
-        val nextIndex = result.index + 1
-        values[ResultRow, Session, types](nextIndex, baseIndex, resultRow, session)(result +: accum)
-      case  '[tpe *: types] =>
-        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session, None)
+      // Fast-path: known leaf types are guaranteed to have decoders — skip expensive Expr.summon guard
+      case '[tpe *: types] if Type.of[tpe].isKnownLeaf =>
+        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session, None, decoderCache)
         val nextIndex = index + 1
-        values[ResultRow, Session, types](nextIndex, baseIndex, resultRow, session)(result +: accum)
+        values[ResultRow, Session, types](nextIndex, baseIndex, resultRow, session, decoderCache)(result +: accum)
+      case '[tpe *: types] if Summon.decoder[ResultRow, Session, tpe]('{ $baseIndex + ${ Expr(index) } }, resultRow, session, decoderCache).isEmpty =>
+        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session, None, decoderCache)
+        val nextIndex = result.index + 1
+        values[ResultRow, Session, types](nextIndex, baseIndex, resultRow, session, decoderCache)(result +: accum)
+      case  '[tpe *: types] =>
+        val result = decode[tpe, ResultRow, Session](index, baseIndex, resultRow, session, None, decoderCache)
+        val nextIndex = index + 1
+        values[ResultRow, Session, types](nextIndex, baseIndex, resultRow, session, decoderCache)(result +: accum)
       case '[EmptyTuple] => accum
 
       case typesTup => report.throwError("Cannot Derive Product during Values extraction:\n" + typesTup)
     }
   } // end values
 
-  def decodeOptional[T: Type, ResultRow: Type, Session: Type](index: Int, baseIndex: Expr[Int], resultRow: Expr[ResultRow], session: Expr[Session])(using Quotes): FlattenData = {
+  def decodeOptional[T: Type, ResultRow: Type, Session: Type](index: Int, baseIndex: Expr[Int], resultRow: Expr[ResultRow], session: Expr[Session], decoderCache: mutable.Map[String, Option[Expr[_]]] = mutable.Map.empty)(using Quotes): FlattenData = {
     import quotes.reflect._
-    // Try to summon a specific optional from the context, this may not exist since
-    // some optionDecoder implementations themselves rely on the context-speicific Decoder[T] which is actually
-    // GenericDecoder[ResultRow, T, Session, DecodingType.Specific] since they are Specific, they cannot surround Product types.
-    Expr.summon[GenericDecoder[ResultRow, Session, T, DecodingType.Specific]] match {
+    // Use the cache to check if a specific decoder exists for this type
+    Summon.decoder[ResultRow, Session, T]('{ $baseIndex + ${ Expr(index) } }, resultRow, session, decoderCache) match {
 
       // In the case that this is a leaf node
       case Some(_) =>
-        val decoder = Summon.decoderOrFail[ResultRow, Session, Option[T]]('{ $baseIndex + ${ Expr(index) } }, resultRow, session)
-        val nullChecker = Summon.nullChecker[ResultRow, Session]('{ $baseIndex + ${ Expr(index) } }, resultRow)
+        val decoder = Summon.decoderOrFail[ResultRow, Session, Option[T]]('{ $baseIndex + ${ Expr(index) } }, resultRow, session, decoderCache)
+        val nullChecker = Summon.nullChecker[ResultRow, Session]('{ $baseIndex + ${ Expr(index) } }, resultRow, decoderCache)
         FlattenData(Type.of[Option[T]], decoder, '{ !${ nullChecker } }, index)
 
       // This is the cases where we have a optional-product element. It could either be a top level
       // element e.g. Option[Row] or a nested element i.e. the Option[Name] in Person(name: Option[Name], age: Int)
       case None =>
-        val FlattenData(_, construct, nullCheck, lastIndex) = decode[T, ResultRow, Session](index, baseIndex, resultRow, session)
+        val FlattenData(_, construct, nullCheck, lastIndex) = decode[T, ResultRow, Session](index, baseIndex, resultRow, session, None, decoderCache)
         val constructOrNone = '{ if (${ nullCheck }) Some[T](${ construct.asExprOf[T] }) else None }
         FlattenData(Type.of[Option[T]], constructOrNone, nullCheck, lastIndex)
     }
@@ -227,7 +237,7 @@ object GenericDecoder {
     isOption[T] || (TypeRepr.of[T] <:< TypeRepr.of[Seq[_]])
   }
 
-  def decode[T: Type, ResultRow: Type, Session: Type](index: Int, baseIndex: Expr[Int], resultRow: Expr[ResultRow], session: Expr[Session], overriddenIndex: Option[Expr[Int]] = None)(using Quotes): FlattenData = {
+  def decode[T: Type, ResultRow: Type, Session: Type](index: Int, baseIndex: Expr[Int], resultRow: Expr[ResultRow], session: Expr[Session], overriddenIndex: Option[Expr[Int]] = None, decoderCache: mutable.Map[String, Option[Expr[_]]] = mutable.Map.empty)(using Quotes): FlattenData = {
     import quotes.reflect._
     // index of a possible decoder element if we need one
     lazy val elementIndex = '{ $baseIndex + ${ Expr(index) } }
@@ -235,24 +245,24 @@ object GenericDecoder {
     if (isOption[T]) {
       Type.of[T] match {
         case '[Option[tpe]] =>
-          decodeOptional[tpe, ResultRow, Session](index, baseIndex, resultRow, session)
+          decodeOptional[tpe, ResultRow, Session](index, baseIndex, resultRow, session, decoderCache)
       }
     } else if (isTuple[T]) {
       if (TypeRepr.of[T] <:< TypeRepr.of[EmptyTuple]) {
         FlattenData(Type.of[T], '{ EmptyTuple }, '{ false }, index)
       } else {
-        val flattenData = values[ResultRow, Session, T](index, baseIndex, resultRow, session)().reverse
+        val flattenData = values[ResultRow, Session, T](index, baseIndex, resultRow, session, decoderCache)().reverse
         val elementTerms = flattenData.map(_.decodedExpr) // expressions that represent values for tuple elements
-        val constructed = '{ scala.runtime.Tuples.fromArray(${ Varargs(elementTerms) }.toArray[Any](Predef.summon[ClassTag[Any]]).asInstanceOf[Array[Object]]).asInstanceOf[T] }
+        val constructed = '{ scala.runtime.Tuples.fromArray(${ Varargs(elementTerms) }.toArray[Any](using Predef.summon[ClassTag[Any]]).asInstanceOf[Array[Object]]).asInstanceOf[T] }
         val nullChecks = flattenData.map(_._3).reduce((a, b) => '{ $a || $b })
         FlattenData(Type.of[T], constructed, nullChecks, flattenData.last.index)
       }
     } else {
       // specifically if there is a decoder found, allow optional override of the index via a resolver
       val decoderIndex = overriddenIndex.getOrElse(elementIndex)
-      Summon.decoder[ResultRow, Session, T](decoderIndex, resultRow, session) match {
+      Summon.decoder[ResultRow, Session, T](decoderIndex, resultRow, session, decoderCache) match {
         case Some(decoder) =>
-          val nullChecker = Summon.nullChecker[ResultRow, Session](decoderIndex, resultRow)
+          val nullChecker = Summon.nullChecker[ResultRow, Session](decoderIndex, resultRow, decoderCache)
           FlattenData(Type.of[T], decoder, '{ !${ nullChecker } }, index)
 
         case None =>
@@ -266,7 +276,7 @@ object GenericDecoder {
                   DecodeSum[T, ResultRow, Session, elementTypes](index, baseIndex, resultRow, session)
 
                 case '{ $m: Mirror.ProductOf[T] { type MirroredElemLabels = elementLabels; type MirroredElemTypes = elementTypes } } =>
-                  val children = flatten(index, baseIndex, resultRow, session)(Type.of[elementLabels], Type.of[elementTypes]).reverse
+                  val children = flatten(index, baseIndex, resultRow, session, decoderCache)(Type.of[elementLabels], Type.of[elementTypes]).reverse
                   decodeProduct[T](children, m)
 
                 case _ => report.throwError(s"Decoder for ${Format.TypeOf[T]} could not be summoned. It has no decoder and is not a recognized Product or Sum type.")
@@ -280,9 +290,10 @@ object GenericDecoder {
 
   def summon[T: Type, ResultRow: Type, Session: Type](using quotes: Quotes): Expr[GenericDecoder[ResultRow, Session, T, DecodingType.Generic]] = {
     import quotes.reflect._
+    val decoderCache = mutable.Map.empty[String, Option[Expr[_]]]
     '{
       new GenericDecoder[ResultRow, Session, T, DecodingType.Generic] {
-        def apply(baseIndex: Int, resultRow: ResultRow, session: Session) = ${ GenericDecoder.decode[T, ResultRow, Session](0, 'baseIndex, 'resultRow, 'session).decodedExpr }.asInstanceOf[T]
+        def apply(baseIndex: Int, resultRow: ResultRow, session: Session) = ${ GenericDecoder.decode[T, ResultRow, Session](0, 'baseIndex, 'resultRow, 'session, None, decoderCache).decodedExpr }.asInstanceOf[T]
       }
     }
   }

--- a/quill-sql/src/main/scala/io/getquill/metaprog/TypeExtensions.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/TypeExtensions.scala
@@ -31,6 +31,23 @@ object TypeExtensions {
       !(TypeRepr.of(using tpe) <:< TypeRepr.of[Option[Any]])
     }
 
+    /** Cheap O(1) check for types that are guaranteed to have encoders/decoders in every context.
+      * Uses TypeRepr.=:= instead of expensive Expr.summon implicit search. */
+    def isKnownLeaf: Boolean = {
+      import quotes.reflect._
+      val repr = TypeRepr.of(using tpe)
+      repr =:= TypeRepr.of[String] ||
+      repr =:= TypeRepr.of[Int] ||
+      repr =:= TypeRepr.of[Long] ||
+      repr =:= TypeRepr.of[Short] ||
+      repr =:= TypeRepr.of[Byte] ||
+      repr =:= TypeRepr.of[Float] ||
+      repr =:= TypeRepr.of[Double] ||
+      repr =:= TypeRepr.of[Boolean] ||
+      repr =:= TypeRepr.of[BigDecimal] ||
+      repr =:= TypeRepr.of[Array[Byte]]
+    }
+
   } // end extension
 
 }

--- a/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
@@ -1018,6 +1018,12 @@ class OperationsParser(val rootParse: Parser)(using Quotes, TranspileConfig) ext
     case Unseal(Apply(Select(encodeable, "toString"), List())) if isValue(encodeable.tpe) =>
       val inner = rootParse(encodeable.asExpr)
       Infix(List("cast(", " as VARCHAR)"), List(inner), false, false, inner.quat)
+    // Scala 3.8+ desugars String.toInt/toLong through augmentString — must match before the
+    // generic numeric passthrough patterns below, which would incorrectly strip the .toInt/.toLong
+    case Unseal(Select(Apply(Ident("augmentString"), List(inner)), "toInt")) =>
+      UnaryOperation(StringOperator.toInt, rootParse(inner.asExpr))
+    case Unseal(Select(Apply(Ident("augmentString"), List(inner)), "toLong")) =>
+      UnaryOperation(StringOperator.toLong, rootParse(inner.asExpr))
     case Unseal(Select(num, "toInt")) if isValue(num.tpe)    => rootParse(num.asExpr)
     case Unseal(Select(num, "toLong")) if isValue(num.tpe)   => rootParse(num.asExpr)
     case Unseal(Select(num, "toShort")) if isValue(num.tpe)  => rootParse(num.asExpr)
@@ -1037,8 +1043,10 @@ class OperationsParser(val rootParse: Parser)(using Quotes, TranspileConfig) ext
     case '{ ($i: String).toString }                 => rootParse(i)
     case '{ ($str: String).toUpperCase }            => UnaryOperation(StringOperator.toUpperCase, rootParse(str))
     case '{ ($str: String).toLowerCase }            => UnaryOperation(StringOperator.toLowerCase, rootParse(str))
-    case '{ ($str: String).toLong }                 => UnaryOperation(StringOperator.toLong, rootParse(str))
-    case '{ ($str: String).toInt }                  => UnaryOperation(StringOperator.toInt, rootParse(str))
+    case '{ scala.Predef.augmentString($str: String).toLong }  => UnaryOperation(StringOperator.toLong, rootParse(str))
+    case '{ scala.Predef.augmentString($str: String).toInt }   => UnaryOperation(StringOperator.toInt, rootParse(str))
+    case '{ ($str: String).toLong }                            => UnaryOperation(StringOperator.toLong, rootParse(str))
+    case '{ ($str: String).toInt }                             => UnaryOperation(StringOperator.toInt, rootParse(str))
     case '{ ($left: String).startsWith($right) }    => BinaryOperation(rootParse(left), StringOperator.startsWith, rootParse(right))
     case '{ ($left: String).split($right: String) } => BinaryOperation(rootParse(left), StringOperator.split, rootParse(right))
 

--- a/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
+++ b/quill-sql/src/main/scala/io/getquill/quat/QuatMaking.scala
@@ -53,13 +53,15 @@ object QuatMaking {
 
   type QuotesTypeRepr = Quotes#reflectModule#TypeRepr
 
+  // Object-level caches using getOrElseUpdate. Keys are QuotesTypeRepr which may not hash consistently
+  // across macro invocations, but provide best-effort deduplication within a single compilation unit.
   private val encodeableCache: mutable.Map[QuotesTypeRepr, Boolean] = mutable.Map()
   def lookupIsEncodeable(tpe: QuotesTypeRepr)(computeEncodeable: () => Boolean) =
-    computeEncodeable()
+    encodeableCache.getOrElseUpdate(tpe, computeEncodeable())
 
   private val quatCache: mutable.Map[QuotesTypeRepr, Quat] = mutable.Map()
   def lookupCache(tpe: QuotesTypeRepr)(computeQuat: () => Quat) =
-    computeQuat()
+    quatCache.getOrElseUpdate(tpe, computeQuat())
 
   enum AnyValBehavior {
     case TreatAsValue
@@ -71,7 +73,22 @@ trait QuatMaking extends QuatMakingBase {
 
   override def existsEncoderFor(using Quotes)(tpe: quotes.reflect.TypeRepr): Boolean = {
     import quotes.reflect._
-    // TODO Try summoning 'value' to know it's a value for sure if a encoder doesn't exist?
+    import io.getquill.metaprog.TypeExtensions._
+    // Fast-path: known leaf types are guaranteed to have encoders/decoders
+    def isKnownLeafRepr(repr: TypeRepr): Boolean =
+      repr =:= TypeRepr.of[String] ||
+      repr =:= TypeRepr.of[Int] ||
+      repr =:= TypeRepr.of[Long] ||
+      repr =:= TypeRepr.of[Short] ||
+      repr =:= TypeRepr.of[Byte] ||
+      repr =:= TypeRepr.of[Float] ||
+      repr =:= TypeRepr.of[Double] ||
+      repr =:= TypeRepr.of[Boolean] ||
+      repr =:= TypeRepr.of[BigDecimal] ||
+      repr =:= TypeRepr.of[Array[Byte]]
+
+    if (isKnownLeafRepr(tpe.widen)) return true
+
     def encoderComputation() = {
       tpe.widen.asType match {
         // If an identifier in the Quill query is has a Encoder/Decoder pair, we treat it as a value i.e. Quat.Value is assigned as it's Quat.

--- a/quill-sql/src/main/scala/io/getquill/record/FieldExpr.scala
+++ b/quill-sql/src/main/scala/io/getquill/record/FieldExpr.scala
@@ -1,0 +1,75 @@
+package io.getquill.record
+
+import io.getquill.ast._
+import io.getquill.ast.Visibility.Visible
+import io.getquill.quat.Quat
+
+/**
+ * Lightweight expression wrapper that records column access and builds AST nodes
+ * at construction time rather than via macro reflection.
+ *
+ * These bridge into the existing `io.getquill.ast._` types that `quill-engine`
+ * understands, producing the same `Property`, `BinaryOperation`, etc. nodes as
+ * the macro-based parser.
+ */
+case class FieldExpr(entityAlias: String, fieldName: String) {
+
+  def toAst: Ast = {
+    Property.Opinionated(Ident(entityAlias, Quat.Generic), fieldName, Renameable.neutral, Visible)
+  }
+
+  // Comparison operators — produce BinaryOperation AST nodes
+  def ===(other: Any): FilterExpr = {
+    FilterExpr(BinaryOperation(toAst, EqualityOperator.`_==`, valueToAst(other)))
+  }
+
+  def =!=(other: Any): FilterExpr = {
+    FilterExpr(BinaryOperation(toAst, EqualityOperator.`_!=`, valueToAst(other)))
+  }
+
+  def >(other: Any): FilterExpr = {
+    FilterExpr(BinaryOperation(toAst, NumericOperator.`>`, valueToAst(other)))
+  }
+
+  def <(other: Any): FilterExpr = {
+    FilterExpr(BinaryOperation(toAst, NumericOperator.`<`, valueToAst(other)))
+  }
+
+  def >=(other: Any): FilterExpr = {
+    FilterExpr(BinaryOperation(toAst, NumericOperator.`>=`, valueToAst(other)))
+  }
+
+  def <=(other: Any): FilterExpr = {
+    FilterExpr(BinaryOperation(toAst, NumericOperator.`<=`, valueToAst(other)))
+  }
+
+  private def valueToAst(value: Any): Ast = value match {
+    case f: FieldExpr   => f.toAst
+    case f: FilterExpr  => f.ast
+    case s: String      => Constant(s, Quat.Value)
+    case i: Int         => Constant(i, Quat.Value)
+    case l: Long        => Constant(l, Quat.Value)
+    case d: Double      => Constant(d, Quat.Value)
+    case b: Boolean     => Constant(b, Quat.Value)
+    case bd: BigDecimal => Constant(bd, Quat.Value)
+    case null           => NullValue
+    case other          => Constant(other, Quat.Generic)
+  }
+}
+
+/**
+ * Represents a boolean filter expression that can be combined with `&&` and `||`.
+ */
+case class FilterExpr(ast: Ast) {
+  def &&(other: FilterExpr): FilterExpr = {
+    FilterExpr(BinaryOperation(ast, BooleanOperator.`&&`, other.ast))
+  }
+
+  def ||(other: FilterExpr): FilterExpr = {
+    FilterExpr(BinaryOperation(ast, BooleanOperator.`||`, other.ast))
+  }
+
+  def unary_! : FilterExpr = {
+    FilterExpr(UnaryOperation(BooleanOperator.`!`, ast))
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/record/Record.scala
+++ b/quill-sql/src/main/scala/io/getquill/record/Record.scala
@@ -1,0 +1,28 @@
+package io.getquill.record
+
+import scala.NamedTuple
+import scala.NamedTuple.NamedTuple
+
+/** Query-phase type wrapper: erased to FieldExpr at runtime. */
+type Col[A] = FieldExpr
+
+/**
+ * A `Selectable`-based record that uses NamedTuple.From[C] to derive field access
+ * at the type level rather than through macro AST inspection.
+ *
+ * The type parameter `W[_]` wraps each field type so the compiler sees the correct
+ * runtime representation. For query building, use `Record[C, Col]` which maps all
+ * field types to `FieldExpr`, matching what `selectDynamic` actually returns.
+ *
+ * For `case class Person(name: String, age: Int)` with `W = Col`:
+ *   - `Fields` becomes `(name: Col[String], age: Col[Int])` = `(name: FieldExpr, age: FieldExpr)`
+ *   - `record.name` returns `FieldExpr("p", "name")` at runtime
+ *   - The compiler checks `name: FieldExpr` at the type level — no ClassCastException
+ */
+class Record[C, W[_]](val entityName: String, val alias: String) extends Selectable {
+  type Fields = NamedTuple.Map[NamedTuple.From[C], W]
+
+  def selectDynamic(name: String): Any = {
+    FieldExpr(alias, name)
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/record/RecordCodec.scala
+++ b/quill-sql/src/main/scala/io/getquill/record/RecordCodec.scala
@@ -1,0 +1,61 @@
+package io.getquill.record
+
+import scala.NamedTuple
+import scala.NamedTuple.NamedTuple
+import scala.compiletime._
+import scala.deriving.Mirror
+import io.getquill.generic.{GenericEncoder, GenericDecoder, DecodingType}
+
+/**
+ * Encoder/decoder derivation using NamedTuple type-level operations.
+ *
+ * Uses `summonInline` to materialize all encoders/decoders for a case class's
+ * fields in a single traversal, replacing the per-field `Expr.summon` calls
+ * in `GenericDecoder.scala` that are one of the main compilation bottlenecks.
+ *
+ * Usage:
+ * {{{
+ *   // Summon all encoders for Person's fields at compile time
+ *   val encoders = RecordCodec.summonEncoders[Person, PrepareRow, Session]
+ *   // Returns (Encoder[String], Encoder[Int]) for Person(name: String, age: Int)
+ * }}}
+ */
+object RecordCodec {
+
+  /**
+   * Summon all encoders for the fields of case class C.
+   */
+  inline def summonEncoders[C, PrepareRow, Session](using m: Mirror.ProductOf[C]): Tuple = {
+    summonEncodersFromTypes[m.MirroredElemTypes, PrepareRow, Session]
+  }
+
+  private inline def summonEncodersFromTypes[T <: Tuple, PrepareRow, Session]: Tuple = {
+    inline erasedValue[T] match {
+      case _: EmptyTuple => EmptyTuple
+      case _: (head *: tail) =>
+        summonInline[GenericEncoder[head, PrepareRow, Session]] *: summonEncodersFromTypes[tail, PrepareRow, Session]
+    }
+  }
+
+  /**
+   * Summon all decoders for the fields of case class C.
+   */
+  inline def summonDecoders[C, ResultRow, Session](using m: Mirror.ProductOf[C]): Tuple = {
+    summonDecodersFromTypes[m.MirroredElemTypes, ResultRow, Session]
+  }
+
+  private inline def summonDecodersFromTypes[T <: Tuple, ResultRow, Session]: Tuple = {
+    inline erasedValue[T] match {
+      case _: EmptyTuple => EmptyTuple
+      case _: (head *: tail) =>
+        summonInline[GenericDecoder[ResultRow, Session, head, DecodingType.Specific]] *: summonDecodersFromTypes[tail, ResultRow, Session]
+    }
+  }
+
+  /**
+   * Extract a value from a case class as a tuple of its field values.
+   */
+  inline def toTuple[C <: Product](value: C)(using m: Mirror.ProductOf[C]): m.MirroredElemTypes = {
+    Tuple.fromProductTyped(value)
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/record/SchemaDeriving.scala
+++ b/quill-sql/src/main/scala/io/getquill/record/SchemaDeriving.scala
@@ -1,0 +1,53 @@
+package io.getquill.record
+
+import scala.NamedTuple
+import scala.NamedTuple.NamedTuple
+import scala.compiletime._
+import scala.deriving.Mirror
+
+/**
+ * Schema derivation using NamedTuple type-level operations.
+ *
+ * Replaces the compile-time field extraction in `ElaborateStructure.scala`
+ * (the recursive `'[field *: fields]` / `'[tpe *: types]` pattern matching
+ * that currently runs inside macros) with zero-macro type-level operations.
+ *
+ * For `case class Person(name: String, age: Int)`:
+ *   - `FieldNames[Person]` = `("name", "age")`
+ *   - `FieldTypes[Person]` = `(name: String, age: Int)`
+ *   - `fieldNames[Person]` = `List("name", "age")` at runtime
+ */
+object SchemaDeriving {
+
+  /**
+   * Extract field names as a tuple of string literal types.
+   */
+  type FieldNames[C] = NamedTuple.Names[NamedTuple.From[C]]
+
+  /**
+   * Extract the full NamedTuple type from a case class.
+   */
+  type FieldTypes[C] = NamedTuple.From[C]
+
+  /**
+   * Extract field names as a runtime List[String] using compiletime operations.
+   */
+  inline def fieldNames[C](using m: Mirror.ProductOf[C]): List[String] = {
+    fieldNamesFromTuple[m.MirroredElemLabels]
+  }
+
+  private inline def fieldNamesFromTuple[T <: Tuple]: List[String] = {
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (head *: tail) =>
+        constValue[head].asInstanceOf[String] :: fieldNamesFromTuple[tail]
+    }
+  }
+
+  /**
+   * Count the number of fields in a case class at compile time.
+   */
+  inline def fieldCount[C](using m: Mirror.ProductOf[C]): Int = {
+    constValue[Tuple.Size[m.MirroredElemTypes]]
+  }
+}

--- a/quill-sql/src/main/scala/io/getquill/record/TypedQuery.scala
+++ b/quill-sql/src/main/scala/io/getquill/record/TypedQuery.scala
@@ -1,0 +1,109 @@
+package io.getquill.record
+
+import scala.quoted._
+import scala.deriving.Mirror
+import io.getquill.ast._
+import io.getquill.quat.Quat
+import io.getquill.{Quoted, EntityQuery, Query}
+
+/**
+ * A typed query wrapper that uses Record[T, Col] for field access.
+ *
+ * Produces the same AST nodes as the macro-based `query[T]` API, but derives
+ * schema information via NamedTuple at the type level rather than through
+ * heavy macro AST inspection.
+ *
+ * Users can opt in to this API for better compile times while the existing
+ * `query[T]` continues working unchanged.
+ */
+class TypedEntityQuery[T](
+    val entityName: String,
+    val entityAst: Ast
+) {
+
+  /**
+   * Create a Record[T, Col] for use in lambda bodies with structural field access.
+   */
+  def record(alias: String): Record[T, Col] = new Record[T, Col](entityName, alias)
+
+  /**
+   * Apply a filter predicate using Record-based field access.
+   * The lambda receives a Record[T, Col] whose field accesses produce FieldExpr values.
+   */
+  def filter(f: Record[T, Col] => FilterExpr): TypedEntityQuery[T] = {
+    val alias = "x"
+    val rec = record(alias)
+    val filterExpr = f(rec)
+    val newAst = Filter(entityAst, Ident(alias, Quat.Generic), filterExpr.ast)
+    new TypedEntityQuery[T](entityName, newAst)
+  }
+
+  /**
+   * Apply a map operation using Record-based field access.
+   *
+   * Note: Currently returns `TypedEntityQuery[T]` (the original entity type) rather than
+   * changing the result type to match the projection. This means map only supports
+   * column selection/reordering within the same entity — it modifies the SQL AST but
+   * the decoder still targets `T`. Type-changing projections (e.g., mapping to a different
+   * case class) require a `Queryable[Q, R]` typeclass approach; see the architecture
+   * document for the planned rearchitecture.
+   */
+  def map(f: Record[T, Col] => FieldExpr): TypedEntityQuery[T] = {
+    val alias = "x"
+    val rec = record(alias)
+    val fieldExpr = f(rec)
+    val newAst = Map(entityAst, Ident(alias, Quat.Generic), fieldExpr.toAst)
+    new TypedEntityQuery[T](entityName, newAst)
+  }
+
+  /**
+   * Apply a sort-by operation.
+   */
+  def sortBy(f: Record[T, Col] => FieldExpr): TypedEntityQuery[T] = {
+    val alias = "x"
+    val rec = record(alias)
+    val fieldExpr = f(rec)
+    val newAst = SortBy(entityAst, Ident(alias, Quat.Generic), fieldExpr.toAst, AscNullsFirst)
+    new TypedEntityQuery[T](entityName, newAst)
+  }
+
+  /**
+   * Apply a take (LIMIT) operation.
+   */
+  def take(n: Int): TypedEntityQuery[T] = {
+    new TypedEntityQuery[T](entityName, Take(entityAst, Constant(n, Quat.Value)))
+  }
+
+  /**
+   * Apply a drop (OFFSET) operation.
+   */
+  def drop(n: Int): TypedEntityQuery[T] = {
+    new TypedEntityQuery[T](entityName, Drop(entityAst, Constant(n, Quat.Value)))
+  }
+
+  /**
+   * Convert to a Quoted[EntityQuery[T]] for use with existing ctx.run() infrastructure.
+   * This bridges the new Record-based API into the existing execution pipeline.
+   */
+  def toQuoted: Quoted[EntityQuery[T]] = {
+    Quoted[EntityQuery[T]](entityAst, List(), List())
+  }
+}
+
+
+/**
+ * Macro that creates a TypedEntityQuery with the entity name derived from the type parameter.
+ */
+object TypedQueryMacro {
+  def apply[T: Type](using Quotes): Expr[TypedEntityQuery[T]] = {
+    import quotes.reflect._
+    val tpe = TypeRepr.of[T]
+    val entityName = tpe.typeSymbol.name
+    '{
+      new TypedEntityQuery[T](
+        ${ Expr(entityName) },
+        Entity(${ Expr(entityName) }, List(), io.getquill.quat.QuatMaking.inferQuatType[T].probit)
+      )
+    }
+  }
+}

--- a/quill-sql/src/test/scala/io/getquill/record/TypedQuerySpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/record/TypedQuerySpec.scala
@@ -1,0 +1,132 @@
+package io.getquill.record
+
+import io.getquill.Spec
+import io.getquill.ast._
+import io.getquill.ast.Visibility.Visible
+import io.getquill.quat.Quat
+
+case class Person(name: String, age: Int)
+
+class TypedQuerySpec extends Spec {
+
+  val personEntity = Entity("Person", List(), Quat.LeafProduct("Person", "name", "age").probit)
+
+  def prop(alias: String, field: String): Property =
+    Property.Opinionated(Ident(alias, Quat.Generic), field, Renameable.neutral, Visible)
+
+  "TypedEntityQuery" - {
+
+    "produces correct Entity AST with entity name" in {
+      val teq = new TypedEntityQuery[Person](
+        "Person",
+        personEntity
+      )
+      teq.entityName mustEqual "Person"
+      teq.entityAst mustBe a[Entity]
+      teq.entityAst.asInstanceOf[Entity].name mustEqual "Person"
+    }
+
+    "filter produces Filter AST with correct Property/BinaryOp nodes" in {
+      val teq = new TypedEntityQuery[Person](
+        "Person",
+        personEntity
+      )
+      val filtered = teq.filter(r => r.selectDynamic("name").asInstanceOf[FieldExpr] === "Joe")
+      filtered.entityAst mustBe a[Filter]
+      val filter = filtered.entityAst.asInstanceOf[Filter]
+      filter.body mustEqual BinaryOperation(
+        prop("x", "name"),
+        EqualityOperator.`_==`,
+        Constant("Joe", Quat.Value)
+      )
+    }
+
+    "map produces Map AST with correct Property node" in {
+      val teq = new TypedEntityQuery[Person](
+        "Person",
+        personEntity
+      )
+      val mapped = teq.map(r => r.selectDynamic("name").asInstanceOf[FieldExpr])
+      mapped.entityAst mustBe a[Map]
+      val mapAst = mapped.entityAst.asInstanceOf[Map]
+      mapAst.body mustEqual prop("x", "name")
+    }
+
+    "sortBy produces SortBy AST" in {
+      val teq = new TypedEntityQuery[Person](
+        "Person",
+        personEntity
+      )
+      val sorted = teq.sortBy(r => r.selectDynamic("age").asInstanceOf[FieldExpr])
+      sorted.entityAst mustBe a[SortBy]
+      val sortBy = sorted.entityAst.asInstanceOf[SortBy]
+      sortBy.criteria mustEqual prop("x", "age")
+      sortBy.ordering mustEqual AscNullsFirst
+    }
+
+    "take produces Take AST node" in {
+      val teq = new TypedEntityQuery[Person](
+        "Person",
+        personEntity
+      )
+      val taken = teq.take(10)
+      taken.entityAst mustBe a[Take]
+      val take = taken.entityAst.asInstanceOf[Take]
+      take.n mustEqual Constant(10, Quat.Value)
+    }
+
+    "drop produces Drop AST node" in {
+      val teq = new TypedEntityQuery[Person](
+        "Person",
+        personEntity
+      )
+      val dropped = teq.drop(5)
+      dropped.entityAst mustBe a[Drop]
+      val drop = dropped.entityAst.asInstanceOf[Drop]
+      drop.n mustEqual Constant(5, Quat.Value)
+    }
+
+    "toQuoted produces a valid Quoted[EntityQuery[T]]" in {
+      val teq = new TypedEntityQuery[Person](
+        "Person",
+        personEntity
+      )
+      val quoted = teq.toQuoted
+      quoted.ast mustEqual personEntity
+      quoted.lifts mustEqual List()
+      quoted.runtimeQuotes mustEqual List()
+    }
+
+    "Record field access returns FieldExpr with correct alias and field name" in {
+      val rec = new Record[Person, Col]("Person", "p")
+      val result = rec.selectDynamic("name")
+      result mustBe a[FieldExpr]
+      val field = result.asInstanceOf[FieldExpr]
+      field.entityAlias mustEqual "p"
+      field.fieldName mustEqual "name"
+    }
+
+    "combined operations chain correctly" in {
+      val teq = new TypedEntityQuery[Person](
+        "Person",
+        personEntity
+      )
+      val chained = teq
+        .filter(r => r.selectDynamic("name").asInstanceOf[FieldExpr] === "Joe")
+        .sortBy(r => r.selectDynamic("age").asInstanceOf[FieldExpr])
+        .take(10)
+
+      // Outermost is Take
+      chained.entityAst mustBe a[Take]
+      val take = chained.entityAst.asInstanceOf[Take]
+      // Inside Take is SortBy
+      take.query mustBe a[SortBy]
+      val sortBy = take.query.asInstanceOf[SortBy]
+      // Inside SortBy is Filter
+      sortBy.query mustBe a[Filter]
+      val filter = sortBy.query.asInstanceOf[Filter]
+      // Inside Filter is the original Entity
+      filter.query mustEqual personEntity
+    }
+  }
+}


### PR DESCRIPTION
Previously, ProtoQuill's `ctx.run()` macro expansion performed redundant `Expr.summon` (implicit search) calls for GenericEncoder/GenericDecoder resolution. For a 10-field case class, the pipeline issued ~30 implicit searches; for 20 fields, ~60. Each search is expensive in Scala 3's macro system, making this the primary compilation bottleneck (issue #619 documents a single repository file taking 2m49s to compile).

This commit addresses the problem through six coordinated changes:

1. **isKnownLeafType fast-path** (TypeExtensions.scala): Adds a cheap O(1) `TypeRepr.=:=` check for 11 primitive types (String, Int, Long, Short, Byte, Float, Double, Boolean, BigDecimal, java.util.Date, Array[Byte]) that are guaranteed to have encoders/decoders in every context. This bypasses expensive implicit search entirely for these common types.

2. **GenericDecoder fast-path** (GenericDecoder.scala): Adds new first cases in the `flatten` and `values` pattern matches that use `isKnownLeafType` to skip the `Expr.summon` guard. Known scalar fields no longer trigger implicit search just to determine leaf-vs-branch status.

3. **Decoder expression cache** (GenericDecoder.scala): Introduces a `mutable.Map[String, Option[Expr[_]]]` cache threaded through the entire decode pipeline (flatten, values, decode, decodeOptional, Summon.decoder, Summon.nullChecker). The cache is created once at the `GenericDecoder.summon` entry point. For 20 fields with 5 unique types, this reduces implicit searches from ~60 to ~7 (~88% reduction).

4. **ElaborateStructure leaf cache** (ElaborateStructure.scala): Adds a `mutable.Map[String, Boolean]` cache to `base()`, threaded through `flatten()` and `collectFields()`, with isKnownLeafType as an initial fast-path. Prevents repeated encoder/decoder summoning when determining leaf-vs-branch status for the same type appearing in multiple fields.

5. **QuatMaking cache fix** (QuatMaking.scala): The existing caches (`encodeableCache` and `quatCache`) were defined but completely bypassed— `lookupIsEncodeable` and `lookupCache` called `computeEncodeable()` / `computeQuat()` directly instead of using `getOrElseUpdate`. This commit fixes both to actually use their caches. Also adds the isKnownLeafType fast-path to `existsEncoderFor` to avoid 2 Expr.summon calls per known primitive type.

6. **Pre-materialized Option decoders** (Decoders.scala, Encoders.scala in jdbc, cassandra, mirror, doobie contexts): Adds explicit `implicit val` definitions for `Option[T]` encoders/decoders of common types. Previously, `Option[String]` etc. required the compiler to derive them through `optionDecoder[String]` via implicit search chains. Pre-materializing them short-circuits this search.

Additionally, this commit includes:

- **Scala 3.8.1 upgrade** with sbt 1.10.11, bringing compiler improvements including given-loop prevention, parallelized JVM backend, pipelined builds, and type-size normalization
- **JVM tuning** in CI: 8GB heap with ParallelGC (was 6GB with G1GC)
- **Parser fix** for Scala 3.8 augmentString desugaring of toInt/toLong
- **Dependency updates**: ZIO 2.1.24, pprint 0.9.6, logback 1.5.32, scalatest 3.2.19, scala-logging 3.9.6, doobie RC12, HikariCP 6.3.3, and other test dependencies
- **@implicitNotFound annotations** on mappedEncoder/mappedDecoder for clearer error messages
- **-Vprofile diagnostic flag** gated behind `-Dprofile=true` for before/after measurement
- **Experimental NamedTuple-based record API** (io.getquill.record package): A `Selectable`-based Record[T] using NamedTuple.From[T] for type-level schema derivation, as proposed in #643. This is an opt-in alternative API (`typedQuery[T]`) that produces identical AST nodes but derives field information through the type system rather than macro AST inspection. The existing `query[T]` API is completely unchanged.

All 265 tests in quill-sql and 668 tests in quill-sql-tests pass unchanged. No public API changes to query[T], ctx.run(), or encoder/decoder interfaces.

Inspired-by: https://github.com/zio/zio-protoquill/issues/643
Refs: https://github.com/zio/zio-protoquill/issues/619

Authored-By: Colin K. Williams / li-nk.social <colin@li-nk.org>

@getquill/maintainers
