### PR TITLE
refactor(macros): modernize Quotes usage, rename qctx to quotes

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/QueryExecution.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/QueryExecution.scala
@@ -196,8 +196,8 @@ object QueryExecution {
       contextOperation: Expr[ContextOperation.Single[I, T, Nothing, D, N, PrepareRow, ResultRow, Session, Ctx, Res]],
       fetchSize: Expr[Option[Int]],
       wrap: Expr[OuterSelectWrap]
-  )(using val qctx: Quotes, QAC: Type[QAC[_, _]]) {
-    import qctx.reflect.{Try => _, _}
+  )(using quotes: Quotes, QAC: Type[QAC[_, _]]) {
+    import quotes.reflect.{Try => _, _}
     import Execution._
 
     val transpileConfig = SummonTranspileConfig()
@@ -419,7 +419,7 @@ object QueryExecution {
       ctx: Expr[ContextOperation.Single[I, T, Nothing, D, N, PrepareRow, ResultRow, Session, Ctx, Res]],
       fetchSize: Expr[Option[Int]],
       wrap: Expr[OuterSelectWrap]
-  )(using qctx: Quotes): Expr[Res] = new RunQuery[I, T, ResultRow, PrepareRow, Session, D, N, Ctx, Res](quotedOp, ctx, fetchSize, wrap).apply()
+  )(using Quotes): Expr[Res] = new RunQuery[I, T, ResultRow, PrepareRow, Session, D, N, Ctx, Res](quotedOp, ctx, fetchSize, wrap).apply()
 
 } // end QueryExecution
 

--- a/quill-sql/src/main/scala/io/getquill/generic/DeconstructElaboratedEntityLevels.scala
+++ b/quill-sql/src/main/scala/io/getquill/generic/DeconstructElaboratedEntityLevels.scala
@@ -28,8 +28,8 @@ object DeconstructElaboratedEntityLevels {
 
 // TODO Unify this with DeconstructElaboratedEntities. This will generate the fields
 // and the labels can be generated separately and zipped in the case oc DeconstructElaboratedEntity
-private[getquill] class DeconstructElaboratedEntityLevels(using val qctx: Quotes) {
-  import qctx.reflect._
+private[getquill] class DeconstructElaboratedEntityLevels(using val quotes: Quotes) {
+  import quotes.reflect._
   import io.getquill.metaprog.Extractors._
   import io.getquill.generic.ElaborateStructure.Term
 

--- a/quill-sql/src/main/scala/io/getquill/parser/ParserHelpers.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/ParserHelpers.scala
@@ -127,7 +127,7 @@ object ParserHelpers {
     } // end AssignmentTerm
   } // end Assignments
 
-  trait PropertyParser(implicit val qctx: Quotes) {
+  trait PropertyParser(using quotes: Quotes) {
     import quotes.reflect.{Ident => TIdent, ValDef => TValDef, _}
     import io.getquill.Embedded
 
@@ -368,7 +368,7 @@ object ParserHelpers {
 
     def rootParse: Parser
 
-    // don't change to ValDef or might override the real valdef in qctx.reflect
+    // don't change to ValDef or might override the real valdef in quotes.reflect
     object ValDefTerm {
       def unapply(using Quotes, History, TranspileConfig)(tree: quotes.reflect.Tree): Option[Ast] = {
         import quotes.reflect.{Ident => TIdent, ValDef => TValDef, _}


### PR DESCRIPTION
## Summary

Addresses suggestions from the Scala 3 community build review (scala/scala3#12174, relates to #2):

- **Remove `val` from Quotes parameters** in `ParserHelpers.PropertyParser` and `QueryExecution.RunQuery` to avoid storing `Quotes` as a class field. Contextual `Quotes` instances should not be stored in fields as it can cause the wrong instance to be used and adds unnecessary overhead.
- **Rename legacy `qctx` to `quotes`** following Scala 3 naming conventions across all three affected files.
- `DeconstructElaboratedEntityLevels` retains `val` because its internal structure exposes path-dependent types (`Symbol`, `TypeRepr`) in member signatures — but is renamed from `qctx` to `quotes` for consistency.

Note: The `Extractors` object suggestion from the community build review is already implemented. The scala/scala3#12179 workaround in `EncodingDsl.scala` remains necessary as that upstream issue is still open.

### Files changed
- `quill-sql/.../context/QueryExecution.scala`
- `quill-sql/.../generic/DeconstructElaboratedEntityLevels.scala`
- `quill-sql/.../parser/ParserHelpers.scala`

## Test plan
- [x] `sbt compile` passes across all modules

cc @li-nkSN