### PR TITLE
Remove isCommunityRemoteBuild scalatest version override

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,7 @@ val isCommunityBuild =
 val isCommunityRemoteBuild =
   sys.props.getOrElse("communityRemote", "false").toBoolean
 
-lazy val scalatestVersion =
-  if (isCommunityRemoteBuild) "3.2.7" else "3.2.19"
+lazy val scalatestVersion = "3.2.19"
 
 lazy val baseModules = Seq[sbt.ClasspathDep[sbt.ProjectReference]](
   `quill-sql`


### PR DESCRIPTION
## Summary
- Remove the `isCommunityRemoteBuild` conditional that forced scalatest 3.2.7 (which was never published for `_3`)
- Use scalatest 3.2.19 unconditionally

## Context
This is in support of updating protoquill in the [Scala 3 community build](https://nightly.scala-lang.org/docs/contributing/community-build.html). The community build passes `-DcommunityRemote=true` which triggered the old 3.2.7 version, causing resolution failures.

## Test plan
- Verified locally by running `sbt -DcommunityRemote=true '++3.8.3-RC1!' runCommunityBuild` — all tests pass