### PR TITLE
Run sbt-dependency-submission as GitHub Action

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,22 @@
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: dependency-graph-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: sbt/setup-sbt@v1
+      - uses: scalacenter/sbt-dependency-submission@v3


### PR DESCRIPTION
### Problem

[Github recommends](https://github.blog/changelog/2023-02-08-dependency-submission-suggestions-on-gradle-maven-scala-and-mill-repositories/) submitting dependencies so they can be used e.g. for Dependabot to send notifications about security vulnerabilities.

This happens automatically e.g. for plugins used in CI but not for Scala dependencies (they can be dynamically produced).

### Solution

Use [sbt-dependency-submission](https://github.com/scalacenter/sbt-dependency-submission), to send depdnencies information to Github using [dependencies submission API](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/using-the-dependency-submission-api).

Maintainer needs to [enable dependency graph](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/enabling-the-dependency-graph):
```
Settings > Security > Advanced Security > Dependency Graph > Enable
```

After build on `master`
* dependencies will be populated on: `Insights > Dependency graph` and
* if there are dependencies with known security vulnerabilities you will have in
`Security and quality` > `Dependabot` > `Vulnerabilities`

### Notes

This is already configured for some OS projects like sbt, http4s, doobie, zio-kafka: https://github.com/zio/zio-kafka/pull/1456

It could be handy to have infrastructure for fast security updates.

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
