### PR TITLE
Support Scala 3.9+ changes to `scala.Option` / `scala.Tuple`

### DIFF
--- a/quill-sql/src/main/scala/io/getquill/context/ReflectiveChainLookup.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/ReflectiveChainLookup.scala
@@ -58,11 +58,25 @@ private[getquill] object ReflectivePathChainLookup {
     object Submodule {
       def unapply(lookup: LookupPath): Option[LookupElement.ModuleClass] = {
         val submod = lookup.cls.getDeclaredClasses.find(c => c.getName.endsWith(lookup.path + "$"))
-        submod.orElse {
-          // Odd pattern for top level object: object Foo { object Bar }
-          // there won't be a Bar in getDeclaredClasses but instead a Bar field on Foo whose value is null
-          lookup.cls.getFields.find(_.getName == lookup.path).map(_.getType)
-        }.map(LookupElement.ModuleClass(_))
+        submod
+          .orElse {
+            // Pre-Scala 3.10 nested objects were also exposed as an (uninitialized) static field
+            // on the parent MODULE$, e.g. Mod$.Foo: Mod$Foo$. Scala 3.10 stopped emitting those
+            // fields (scala/scala3#25538), so this path is only useful on older compilers.
+            lookup.cls.getFields.find(_.getName == lookup.path).map(_.getType)
+          }
+          .orElse {
+            // Scala 3.10+: load the nested MODULE$ class by binary name. Parent `Mod$` +
+            // nested `Foo` => `...Mod$Foo$` (and similarly `...Mod$Foo$` + `Bar` => `...Mod$Foo$Bar$`).
+            Try(
+              Class.forName(
+                lookup.cls.getName + lookup.path + "$",
+                false,
+                lookup.cls.getClassLoader
+              )
+            ).toOption
+          }
+          .map(LookupElement.ModuleClass(_))
       }
     }
 

--- a/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
@@ -401,6 +401,30 @@ object Extractors {
     }
   }
 
+  /**
+   * Matches `someOption.orNull`. Since Scala 3.10 the standard library defines
+   * `orNull[A1 >: A | Null]: A1` and the overload taking the `Null <:< A1` evidence
+   * is private to `Option`, so the call is `opt.orNull[A1]` there and
+   * `opt.orNull[A1](ev)` on earlier versions. Matching the tree instead of using a
+   * quoted pattern keeps this working with both standard libraries.
+   */
+  object OrNullMethod {
+    def unapply(expr: Expr[_])(using Quotes): Option[Expr[_]] = {
+      import quotes.reflect._
+      def peelApplies(term: Term): Term =
+        term match {
+          case Apply(inner, _)     => peelApplies(inner)
+          case TypeApply(inner, _) => peelApplies(inner)
+          case other               => other
+        }
+      peelApplies(Untype(expr.asTerm)) match {
+        case Select(receiver, "orNull") if receiver.tpe.widen <:< TypeRepr.of[Option[Any]] =>
+          Some(receiver.asExpr)
+        case _ => None
+      }
+    }
+  }
+
   object TupleName {
     def unapply(str: String): Boolean = str.matches("Tuple[0-9]+")
   }

--- a/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
+++ b/quill-sql/src/main/scala/io/getquill/metaprog/Extractors.scala
@@ -395,7 +395,8 @@ object Extractors {
       import quotes.reflect._
       expr match {
         case '{ type v; ($prop: Any).->[`v`](($value: `v`)) } => Some((prop, value))
-        case _                                                => None
+        case '{ type v; ($prop: Any, ($value: `v`)) } => Some((prop, value))
+        case _                                        => None
       }
     }
   }

--- a/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/Parser.scala
@@ -612,7 +612,7 @@ class OptionParser(rootParse: Parser)(using Quotes, TranspileConfig) extends Par
     case "contains" -@> '{ type t; ($o: Option[`t`]).contains($body: `t`) } =>
       OptionContains(rootParse(o), rootParse(body))
 
-    case '{ ($o: Option[t]).orNull($refl) } =>
+    case OrNullMethod(o) =>
       OptionOrNull(rootParse(o))
 
     case '{ ($o: Option[t]).getOrNull } =>

--- a/quill-sql/src/main/scala/io/getquill/parser/ParserHelpers.scala
+++ b/quill-sql/src/main/scala/io/getquill/parser/ParserHelpers.scala
@@ -209,7 +209,7 @@ object ParserHelpers {
 
       def unapply[T: Type](expr: Expr[Any]): Option[PropertyAlias] =
         expr match {
-          case Lambda1(_, _, '{ ($prop: Any).->[v](${ ConstExpr(alias: String) }) }) =>
+          case Lambda1(_, _, ArrowFunction(prop, ConstExpr(alias: String))) =>
             def path(tree: Expr[_]): List[String] =
               tree match {
                 case a `.` b =>

--- a/quill-sql/src/test/scala/io/getquill/ParticularizationSpec.scala
+++ b/quill-sql/src/test/scala/io/getquill/ParticularizationSpec.scala
@@ -78,6 +78,11 @@ class ParticularizationSpec extends Spec {
         "INSERT INTO Ent (foo,bar) VALUES ($1, $2)", List("foo", "bar"), Static
       )
     }
+    "works with explicit insert - directly constructed assignment tuples" in {
+      ctx.run(query[Ent].insert(e => (e.foo, lift("foo")), e => (e.bar, lift("bar")))).triple mustBe (
+        "INSERT INTO Ent (foo,bar) VALUES ($1, $2)", List("foo", "bar"), Static
+      )
+    }
     "works with explicit insert - dynamic" in {
       val q = quote(query[Ent].insert(_.foo -> lift("foo"), _.bar -> lift("bar")))
       ctx.run(q).triple mustBe (

--- a/quill-sql/src/test/scala/io/getquill/sanity/SimpleQuerySchemaTest.scala
+++ b/quill-sql/src/test/scala/io/getquill/sanity/SimpleQuerySchemaTest.scala
@@ -28,6 +28,12 @@ class SimpleQuerySchemaTest extends Spec {
       }
       ctx.run(q).string mustEqual "SELECT x.colName, x.age FROM tblPerson x"
     }
+    "produce an sql query with a directly constructed column alias tuple" in {
+      inline def q = quote {
+        querySchema[Person]("tblPerson", person => (person.name, "colName"))
+      }
+      ctx.run(q).string mustEqual "SELECT x.colName, x.age FROM tblPerson x"
+    }
     "produce an sql query with a filter and a renamed table and renamed columns" in {
       inline def q = quote {
         querySchema[Person]("tblPerson", _.name -> "colName").filter(p => p.name == "Joe")


### PR DESCRIPTION
Fixes issues spotted by Scala 3 Open Community Build 

### Problem

Scala 3.9 and 3.10 introduced changes in the stdlib that negatively affect the macros: 
- in 3.9 `Option.orNull` [has new public API](https://github.com/scala/scala3/blob/81713374fd8e0380d5775eb6c9026b9474cda2f2/library/src/scala/Option.scala#L256-L260) (previous one is private, but public in binary for compatibity) - it does no longer take explicit implicit evidence
- in 3.10 Tuple `->` is inlined, so `x -> y` pattern can no longer be matched, at this point we're already operating on `(x, y)`

### Solution

Adds dedicated handling for both cases while keeping backward compatibility 

### Notes

Mostly LLM generated, tested locally, passed the OpenCB build for 3.10.nightly (after applying -source:3.4-migration rewrites)

### Checklist

- [ ] Unit test all changes
- [ ] Update `README.md` if applicable
- [ ] Add `[WIP]` to the pull request title if it's work in progress
- [ ] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@getquill/maintainers
