### PR TITLE
Publish under zio org's Sonatype namespace (dev.zio)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,5 @@ jobs:
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.GETQUILL_SONATYPE_TOKEN_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.GETQUILL_SONATYPE_TOKEN_USER }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 inThisBuild(
   List(
-    organization := "io.getquill",
+    organization := "dev.zio",
     homepage := Some(url("https://zio.dev/zio-protoquill")),
     licenses := List(("Apache License 2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     developers := List(


### PR DESCRIPTION
## Summary

Follow-up to #775. Maintainers confirmed the project should publish under the `zio` org's own Sonatype namespace going forward instead of the legacy `io.getquill` one.

- **`build.sbt`**: `organization` changed from `io.getquill` → `dev.zio`. Verified locally with `sbt "show quill-zio/organization"` and `sbt "show quill-zio/publishTo"` — publish target still correctly resolves to the Central Portal snapshot repo.
- **`.github/workflows/ci.yml`**: fixed a secret-name mismatch found while investigating #775 — the workflow was reading `secrets.GETQUILL_SONATYPE_TOKEN_USER` / `secrets.GETQUILL_SONATYPE_TOKEN_PASSWORD`, but the repo's actual secrets are named `SONATYPE_USERNAME` / `SONATYPE_PASSWORD`. The mismatched names resolved to empty strings, so `release` job was authenticating with **blank** credentials, which is almost certainly the real cause of the `Server redirected too many times (20)` failures.

No Scala source changes — package namespace (`io.getquill.*`) is untouched, only the Maven/Sonatype coordinates change.

## Test plan
- [x] `sbt "show quill-zio/organization"` → `dev.zio`
- [x] `sbt "show quill-zio/publishTo"` → `Some(central-snapshots: https://central.sonatype.com/repository/maven-snapshots/)` for all modules
- [ ] CI `release` job succeeds on merge (existing `SONATYPE_USERNAME`/`SONATYPE_PASSWORD` secrets are now actually used)

Closes #775