### PR TITLE
ci: retry bigdata tests once on failure to handle Cassandra flakes

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -177,7 +177,11 @@ function db_build() {
 
 function bigdata_build() {
     wait_for_bigdata
-    sbt -Dmodules=bigdata $SBT_ARGS test
+    sbt -Dmodules=bigdata $SBT_ARGS test || {
+        echo "BigData tests failed, retrying once..."
+        sleep 10
+        sbt -Dmodules=bigdata $SBT_ARGS test
+    }
 }
 
 function full_build() {


### PR DESCRIPTION
## What

Retry the `bigdata` test suite once if it fails, with a 10s pause in between.

## Why

The Cassandra-backed `bigdata` module is intermittently flaky in CI — the
container is occasionally not fully ready by the time the suite starts, even
after `wait_for_bigdata` returns. The failures are not reproducible locally and
clear on a re-run.

This has been running in a downstream fork of ProtoQuill and has removed the
spurious red builds without masking real failures: a genuine breakage fails both
attempts, and the retry is logged (`BigData tests failed, retrying once...`) so
it is visible in the CI output rather than silent.

## Scope

One function in `build/build.sh`. No production code, no test code.

```diff
 function bigdata_build() {
     wait_for_bigdata
-    sbt -Dmodules=bigdata $SBT_ARGS test
+    sbt -Dmodules=bigdata $SBT_ARGS test || {
+        echo "BigData tests failed, retrying once..."
+        sleep 10
+        sbt -Dmodules=bigdata $SBT_ARGS test
+    }
 }
```

---

Part of an effort to upstream a set of fixes maintained in a downstream fork, split
into focused PRs at the maintainers' request. See zio/zio-protoquill#777 for the
full index.
