### PR TITLE
Update quill-engine to 4.8.6 and adapt to the BatchGroup liftings API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ val filteredModules = {
   selectedModules
 }
 
-val zioQuillVersion = "4.8.5"
+val zioQuillVersion = "4.8.6"
 val zioVersion = "2.1.26"
 
 lazy val `quill` =

--- a/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
+++ b/quill-cassandra-zio/src/main/scala/io/getquill/CassandraZioContext.scala
@@ -171,7 +171,7 @@ class CassandraZioContext[+N <: NamingStrategy](val naming: N)
       _ <- {
         val batchGroups =
           groups.flatMap {
-            case BatchGroup(cql, prepare) =>
+            case BatchGroup(cql, prepare, _) =>
               prepare
                 .map(prep => executeAction(cql, prep)(info, dc).provideEnvironment(ZEnvironment(env)))
           }

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraAsyncContext.scala
@@ -84,7 +84,7 @@ class CassandraAsyncContext[+N <: NamingStrategy](
     implicit val ec = dc
     Future.sequence {
       groups.flatMap {
-        case BatchGroup(cql, prepare) =>
+        case BatchGroup(cql, prepare, _) =>
           prepare.map(executeAction(cql, _)(info, dc))
       }
     }.map(_ => ())

--- a/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
+++ b/quill-cassandra/src/main/scala/io/getquill/CassandraSyncContext.scala
@@ -67,7 +67,7 @@ class CassandraSyncContext[+N <: NamingStrategy](
 
   def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: Runner): Unit =
     groups.foreach {
-      case BatchGroup(cql, prepare) =>
+      case BatchGroup(cql, prepare, _) =>
         prepare.foreach(executeAction(cql, _)(info, dc))
     }
 }

--- a/quill-doobie/src/main/scala/io/getquill/doobie/DoobieContextBase.scala
+++ b/quill-doobie/src/main/scala/io/getquill/doobie/DoobieContextBase.scala
@@ -201,7 +201,7 @@ trait DoobieContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
   )(
     info: ExecutionInfo,
     dc: Runner
-  ): ConnectionIO[List[Long]] = groups.flatTraverse { case BatchGroup(sql, preps) =>
+  ): ConnectionIO[List[Long]] = groups.flatTraverse { case BatchGroup(sql, preps, _) =>
     HC.prepareStatement(sql) {
       useConnection { implicit connection =>
         for {
@@ -220,7 +220,7 @@ trait DoobieContextBase[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
     info: ExecutionInfo,
     dc: Runner
   ): ConnectionIO[List[A]] = groups.flatTraverse {
-    case BatchGroupReturning(sql, returningBehavior, preps) =>
+    case BatchGroupReturning(sql, returningBehavior, preps, _) =>
       prepareConnections(returningBehavior)(sql) {
 
         useConnection { implicit connection =>

--- a/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioPrepareContext.scala
+++ b/quill-jdbc-zio/src/main/scala/io/getquill/context/qzio/ZioPrepareContext.scala
@@ -43,7 +43,7 @@ trait ZioPrepareContext[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] extends
   def prepareBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: Runner): PrepareBatchActionResult =
     ZIO.collectAll[Connection, Throwable, PrepareRow, List] {
       val batches = groups.flatMap {
-        case BatchGroup(sql, prepares) =>
+        case BatchGroup(sql, prepares, _) =>
           prepares.map(sql -> _)
       }
       batches.map {

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbExecute.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbExecute.scala
@@ -76,7 +76,7 @@ trait JdbcContextVerbExecute[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] ex
   def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: Runner): Result[List[Long]] =
     withConnectionWrapped { conn =>
       groups.flatMap {
-        case BatchGroup(sql, prepare) =>
+        case BatchGroup(sql, prepare, _) =>
           val ps = conn.prepareStatement(sql)
           //logger.underlying.debug("Batch: {}", sql.take(200) + (if (sql.length > 200) "..." else ""))
           prepare.foreach { f =>
@@ -91,7 +91,7 @@ trait JdbcContextVerbExecute[+Dialect <: SqlIdiom, +Naming <: NamingStrategy] ex
   def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: Runner): Result[List[T]] =
     withConnectionWrapped { conn =>
       groups.flatMap {
-        case BatchGroupReturning(sql, returningBehavior, prepare) =>
+        case BatchGroupReturning(sql, returningBehavior, prepare, _) =>
           val ps = prepareWithReturning(sql, conn, returningBehavior)
           logger.underlying.debug("Batch: {}", sql)
           prepare.foreach { f =>

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbPrepare.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/JdbcContextVerbPrepare.scala
@@ -44,7 +44,7 @@ trait JdbcContextVerbPrepare[+Dialect <: SqlIdiom, +Naming <: NamingStrategy]
       (session: Connection) =>
         seq {
           val batches = groups.flatMap {
-            case BatchGroup(sql, prepares) =>
+            case BatchGroup(sql, prepares, _) =>
               prepares.map(sql -> _)
           }
           batches.map {

--- a/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
+++ b/quill-jdbc/src/main/scala/io/getquill/context/jdbc/SimplifiedContexts.scala
@@ -83,7 +83,7 @@ trait SqliteExecuteOverride[+D <: SqliteDialect, +N <: NamingStrategy] extends J
         "Sqlite does not support Batch-Actions with returning-keys. Quill will attempt to emulate this function with single-row inserts inside a transaction but using this API is not recommended."
       )
       groups.flatMap {
-        case BatchGroupReturning(sql, returningBehavior, prepare) =>
+        case BatchGroupReturning(sql, returningBehavior, prepare, _) =>
           val ps = conn.prepareStatement(sql, java.sql.Statement.RETURN_GENERATED_KEYS)
           logger.underlying.debug("Batch: {}", sql)
           runInTransaction(conn) {
@@ -112,7 +112,7 @@ trait SqlServerExecuteOverride[+N <: NamingStrategy] extends JdbcContextVerbExec
   override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: Runner): Result[List[T]] =
     withConnectionWrapped { conn =>
       groups.flatMap {
-        case BatchGroupReturning(sql, returningBehavior, prepare) =>
+        case BatchGroupReturning(sql, returningBehavior, prepare, _) =>
           val ps = conn.prepareStatement(sql, java.sql.Statement.RETURN_GENERATED_KEYS)
           logger.underlying.debug("Batch: {}", sql)
           val outputs =

--- a/quill-sql-tests/src/test/scala/io/getquill/ported/sqlidiomspec/InfixSpec.scala
+++ b/quill-sql-tests/src/test/scala/io/getquill/ported/sqlidiomspec/InfixSpec.scala
@@ -41,7 +41,7 @@ class InfixSpec extends Spec {
     "full infix query" in {
       val result = testContext.run(sql"SELECT * FROM TestEntity".as[Query[TestEntity]])
       result.string mustEqual
-        "SELECT x.s, x.i, x.l, x.o, x.b FROM (SELECT * FROM TestEntity) AS x"
+        "SELECT * FROM TestEntity"
     }
     // Not supported yet by regular quill either
     // "full infix action returning" in {

--- a/quill-sql/src/main/scala/io/getquill/MirrorContext.scala
+++ b/quill-sql/src/main/scala/io/getquill/MirrorContext.scala
@@ -92,7 +92,7 @@ trait MirrorContextBase[+Dialect <: Idiom, +Naming <: NamingStrategy]
   override def executeBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: Runner): Result[RunBatchActionResult] =
     BatchActionMirror(
       groups.map {
-        case BatchGroup(string, prepare) =>
+        case BatchGroup(string, prepare, _) =>
           (string, prepare.map(_(Row(), session)._2))
       },
       info
@@ -101,7 +101,7 @@ trait MirrorContextBase[+Dialect <: Idiom, +Naming <: NamingStrategy]
   override def executeBatchActionReturning[T](groups: List[BatchGroupReturning], extractor: Extractor[T])(info: ExecutionInfo, dc: Runner): Result[RunBatchActionReturningResult[T]] =
     BatchActionReturningMirror[T](
       groups.map {
-        case BatchGroupReturning(string, returningBehavior, prepare) =>
+        case BatchGroupReturning(string, returningBehavior, prepare, _) =>
           (string, returningBehavior, prepare.map(_(Row(), session)._2))
       },
       extractor,
@@ -127,7 +127,7 @@ trait MirrorContextBase[+Dialect <: Idiom, +Naming <: NamingStrategy]
   def prepareBatchAction(groups: List[BatchGroup])(info: ExecutionInfo, dc: Runner) =
     PrepareBatchMirror(
       groups.map {
-        case BatchGroup(string, prepare) =>
+        case BatchGroup(string, prepare, _) =>
           (string, prepare.map(_(Row(), session)._2))
       },
       info

--- a/quill-sql/src/main/scala/io/getquill/context/Context.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/Context.scala
@@ -188,7 +188,7 @@ trait Context[+Dialect <: Idiom, +Naming <: NamingStrategy]
     inline def runBatchAction[I, A <: Action[I] & QAC[I, Nothing]](inline quoted: Quoted[BatchAction[A]], rowsPerBatch: Int): Result[RunBatchActionResult] = {
       val ca = make.batch[I, Nothing, A, Result[RunBatchActionResult]] { arg =>
         // Supporting only one top-level query batch group. Don't know if there are use-cases for multiple queries.
-        val groups = arg.groups.map((sql, prepare) => BatchGroup(sql, prepare))
+        val groups = arg.groups.map((sql, prepare) => BatchGroup(sql, prepare, Nil))
         self.executeBatchAction(groups.toList)(arg.executionInfo, _summonRunner())
       }
       QueryExecutionBatch.apply(ca, rowsPerBatch)(quoted)
@@ -198,7 +198,7 @@ trait Context[+Dialect <: Idiom, +Naming <: NamingStrategy]
       val ca = make.batch[I, T, A, Result[RunBatchActionReturningResult[T]]] { arg =>
         val returningExt = arg.extractor.requireReturning()
         // Supporting only one top-level query batch group. Don't know if there are use-cases for multiple queries.
-        val groups = arg.groups.map((sql, prepare) => BatchGroupReturning(sql, returningExt.returningBehavior, prepare))
+        val groups = arg.groups.map((sql, prepare) => BatchGroupReturning(sql, returningExt.returningBehavior, prepare, Nil))
         self.executeBatchActionReturning[T](groups.toList, returningExt.extract)(arg.executionInfo, _summonRunner())
       }
       QueryExecutionBatch.apply(ca, rowsPerBatch)(quoted)

--- a/quill-sql/src/main/scala/io/getquill/context/ContextVerbPrepare.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/ContextVerbPrepare.scala
@@ -88,7 +88,7 @@ trait ContextVerbPrepare[+Dialect <: Idiom, +Naming <: NamingStrategy] {
   @targetName("runPrepareBatchAction")
   inline def prepare[I, A <: Action[I] & QAC[I, Nothing]](inline quoted: Quoted[BatchAction[A]]): PrepareBatchActionResult = {
     val ca = make.batch[I, Nothing, A, PrepareBatchActionResult] { arg =>
-      val groups = arg.groups.map((sql, prepare) => BatchGroup(sql, prepare))
+      val groups = arg.groups.map((sql, prepare) => BatchGroup(sql, prepare, Nil))
       self.prepareBatchAction(groups.toList)(arg.executionInfo, _summonPrepareRunner())
     }
     QueryExecutionBatch.apply(ca, 1)(quoted)

--- a/quill-sql/src/main/scala/io/getquill/context/ContextVerbTranslate.scala
+++ b/quill-sql/src/main/scala/io/getquill/context/ContextVerbTranslate.scala
@@ -128,7 +128,7 @@ trait ContextTranslateMacro[+Dialect <: Idiom, +Naming <: NamingStrategy]
   inline def translate[I, A <: Action[I] & QAC[I, Nothing]](inline quoted: Quoted[BatchAction[A]], inline prettyPrint: Boolean): TranslateResult[List[String]] = {
     val ca = make.batch[I, Nothing, A, TranslateResult[List[String]]] { arg =>
       // Supporting only one top-level query batch group. Don't know if there are use-cases for multiple queries.
-      val groups = arg.groups.map((sql, prepare) => BatchGroup(sql, prepare))
+      val groups = arg.groups.map((sql, prepare) => BatchGroup(sql, prepare, Nil))
       self.translateBatchQueryEndpoint(groups.toList, prettyPrint)(arg.executionInfo, _summonTranslateRunner())
     }
     QueryExecutionBatch.apply(ca, 1)(quoted)
@@ -141,7 +141,7 @@ trait ContextTranslateMacro[+Dialect <: Idiom, +Naming <: NamingStrategy]
     val ca = make.batch[I, T, A, TranslateResult[List[String]]] { arg =>
       val returningExt = arg.extractor.requireReturning()
       // Supporting only one top-level query batch group. Don't know if there are use-cases for multiple queries.
-      val groups = arg.groups.map((sql, prepare) => BatchGroupReturning(sql, returningExt.returningBehavior, prepare))
+      val groups = arg.groups.map((sql, prepare) => BatchGroupReturning(sql, returningExt.returningBehavior, prepare, Nil))
       self.translateBatchQueryReturningEndpoint(groups.toList, prettyPrint)(arg.executionInfo, _summonTranslateRunner())
     }
     QueryExecutionBatch.apply(ca, 1)(quoted)


### PR DESCRIPTION
> **Draft — blocked on a zio-quill artifact publish. See "Blocker" below.**

## What

Unpin ProtoQuill from zio-quill 4.8.5 and adapt it to the `BatchGroup` API change
introduced by zio/zio-quill#3146 ("Improve translate function. Make contexts more lazy.").

Three commits:

| Commit | Change |
|---|---|
| `build: update quill-engine to 4.8.6` | `zioQuillVersion` 4.8.5 → 4.8.6 |
| `fix: adapt to BatchGroup liftings field` | pattern matches + constructors across 12 files |
| `fix: update InfixSpec expectation` | test expectation for the lazy-context rendering change |

## The API change

zio/zio-quill#3146 added a `liftings` field to both batch group classes
(`quill-engine/src/main/scala/io/getquill/context/RowContext.scala`):

```diff
-case class BatchGroup(string: String, prepare: List[Prepare])
-case class BatchGroupReturning(string: String, returningBehavior: ReturnAction, prepare: List[Prepare])
+case class BatchGroup(string: String, prepare: List[Prepare], liftings: List[List[ScalarLift]])
+case class BatchGroupReturning(string: String, returningBehavior: ReturnAction, prepare: List[Prepare], liftings: List[List[ScalarLift]])
```

ProtoQuill constructs and destructures these in 12 files across `quill-sql`,
`quill-jdbc`, `quill-jdbc-zio`, `quill-doobie`, and `quill-cassandra*`. This PR adds
a wildcard to each pattern match and `Nil` to each constructor — it does not thread
any lifting data through, so behaviour is unchanged. A follow-up could populate the
field to give ProtoQuill the same lazy-translate capability quill gained in #3146.

The same PR also changed how full infix queries render — raw SQL is now passed
through directly rather than wrapped in a subquery — so one `InfixSpec` expectation
is updated:

```diff
-"SELECT x.s, x.i, x.l, x.o, x.b FROM (SELECT * FROM TestEntity) AS x"
+"SELECT * FROM TestEntity"
```

## Blocker

**`io.getquill:quill-engine` 4.8.6 is not on Maven Central.**

`v4.8.6` is tagged and has a published GitHub release (2025-07-17), but the release
carries 0 assets and no artifacts reached Central for either Scala version — the
latest published `quill-engine_3` and `quill-engine_2.13` are both **4.8.5**:

- https://repo1.maven.org/maven2/io/getquill/quill-engine_3/maven-metadata.xml
- https://repo1.maven.org/maven2/io/getquill/quill-engine_2.13/maven-metadata.xml

So CI on this PR will fail at dependency resolution with `not found: quill-engine_3-4.8.6.pom`
until that release is completed. It seems worth flagging on its own: #3146 landed in
December 2024 and is still not consumable by any downstream, which is what keeps
ProtoQuill pinned to 4.8.5.

If the fix is a re-publish of `v4.8.6`, this PR should go green as-is. If the next
release lands under a different version, only the one line in `build.sbt` needs
changing.

## Verification

The two adaptation commits are running against a build of quill master carrying
#3146 (published privately as `4.8.7-RC1` to work around the above), across the
`quill-sql`, `quill-jdbc`, `quill-jdbc-zio` and `quill-cassandra` modules. They are
unmodified here apart from commit messages retargeted at 4.8.6.

I have not been able to verify them against `io.getquill` 4.8.6 specifically, for
the reason above — though `v4.8.6..master` in zio-quill contains only dependency
bumps and one H2 array-encoder addition, no further engine API change.

---

Part of an effort to upstream a set of fixes maintained in a downstream fork, split
into focused PRs at the maintainers' request. See zio/zio-protoquill#777 for the
full index.
